### PR TITLE
Add CI: pytest + Claude PR review + ml-reviewer

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,32 @@
+name: Claude PR review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for:
+            - Correctness and obvious bugs
+            - Consistency with existing patterns in the repo (see CLAUDE.md)
+            - Code quality, readability, and over-engineering
+            - Test coverage of changed behaviour
+
+            Leave inline comments on specific lines where useful. End with a short summary.
+            Do not approve or block — only comment.

--- a/.github/workflows/ml-review.yml
+++ b/.github/workflows/ml-review.yml
@@ -1,0 +1,46 @@
+name: ML methodology review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'analysis.py'
+      - 'gmm.py'
+      - 'web/main.py'
+      - 'parsing.py'
+      - 'unit_conversions.py'
+      - 'thresholds.py'
+      - 'tests/test_analysis.py'
+      - 'tests/test_gmm_functions.py'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  ml-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run ml-reviewer agent
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model claude-opus-4-7'
+          prompt: |
+            You are reviewing a pull request that touches ML / analysis code.
+
+            Use the ml-reviewer subagent defined in .claude/agents/ml-reviewer.md.
+            Focus on:
+            - Statistical assumptions (GMM, PCA, Mahalanobis, Pearson r)
+            - Parameter choices (K range, n_init, ΔBIC floor, posterior 0.7, χ² 0.99)
+            - Reproducibility and edge cases (tiny cohorts, all-NaN markers)
+            - Whether user-facing methodology copy matches the code
+
+            Leave inline comments at `path:line`. End with the structured output
+            format described in the subagent definition (highest-priority issues,
+            improvements, documentation gaps, what's done well).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - run: pip install -r requirements.txt
+      - run: python -m pytest -q


### PR DESCRIPTION
## Summary
- `tests.yml` runs the 191-test pytest suite on every PR
- `claude-review.yml` runs a general code-quality review via the Claude GitHub App
- `ml-review.yml` runs the existing `ml-reviewer` subagent (Opus 4.7, API key) on PRs touching `analysis.py`, `gmm.py`, `web/main.py`, `parsing.py`, `unit_conversions.py`, `thresholds.py`, or the analysis/gmm tests

This PR is also a smoke test — it should trigger the `tests` and `claude-review` workflows (but not `ml-review`, since no ML files changed).

## Follow-up (manual, not in this PR)
- Install the Claude GitHub App and store `CLAUDE_CODE_OAUTH_TOKEN` (`/install-github-app` from Claude Code)
- Add the `ANTHROPIC_API_KEY` repo secret
- Enable branch protection on `main` requiring the `pytest` status check

## Test plan
- [ ] `tests` job runs and passes
- [ ] `claude-review` job posts a review comment on this PR (requires the App + OAuth secret to be configured first — may no-op on this PR if not yet set up)
- [ ] `ml-review` does **not** run (no ML file paths changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)