### PR TITLE
Add CI: pytest + Claude PR review + ML-reviewer

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/ml-review.yml
+++ b/.github/workflows/ml-review.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   ml-review:
@@ -29,7 +30,7 @@ jobs:
       - name: Run ml-reviewer agent
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model claude-opus-4-7'
           prompt: |
             You are reviewing a pull request that touches ML / analysis code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ Each tab follows the same shape:
 
 `.claude/agents/ml-reviewer.md` defines an `ml-reviewer` subagent (read-only, opus). Invoke it to assess methodology, parameter choices, statistical assumptions, and surface improvements. The agent description is wired for proactive triggering when changes touch `analysis.py`, `gmm.py`, `_investigate_context`, or chart helpers.
 
+## Workflow for major changes
+
+Anything that spans more than one PR — a new feature, a multi-step refactor, a methodology change — must start with a GitHub milestone and child issues, one per intended PR. Use the `/feature` slash command to scaffold the milestone + issues; do not start writing code until the breakdown is approved by the user.
+
+- One issue = one PR. If an issue grows past that, split it.
+- Every PR description must reference its issue with `Closes #N`.
+- Trivial single-PR work (typo fixes, dependency bumps, isolated bug fixes) is exempt — go straight to a branch.
+
 ## Keeping this file current
 
 Update `CLAUDE.md` whenever the project structure, key decisions, or constraints change — for example:


### PR DESCRIPTION
## Summary
- Adds three GitHub Actions workflows: pytest on every PR, a general Claude PR review, and an ML-methodology review (ml-reviewer subagent) that fires only when analysis/ML files change.
- Both review workflows authenticate via a single repo secret (`CLAUDE_CODE_OAUTH_TOKEN`) so v1 setup is one secret, not two.
- Documents the milestone-and-child-issues workflow in CLAUDE.md (one PR per issue, every PR references `Closes #N`, `/feature` scaffolds the breakdown).

This PR is also the **first real test** of whether the OAuth token + `id-token: write` permission combination works — successful runs of "Claude PR review" and "ML methodology review" on this PR are the success criterion.

## Test plan
- [ ] The "tests" workflow runs and passes (pytest, all 191 existing tests).
- [ ] The "Claude PR review" workflow runs to completion (it should leave a comment on this PR).
- [ ] The "ML methodology review" workflow does NOT fire here (no analysis files changed) — paths filter is working.
- [ ] No "OIDC token missing" errors in either workflow's logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)