### PR TITLE
Wire Claude reviews to post inline comments + cut token burn

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,12 +22,35 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --model claude-haiku-4-5-20251001
+            --max-turns 15
+            --allowedTools "Bash(gh:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
           prompt: |
-            Review this pull request for:
-            - Correctness and obvious bugs
-            - Consistency with existing patterns in the repo (see CLAUDE.md)
-            - Code quality, readability, and over-engineering
-            - Test coverage of changed behaviour
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Leave inline comments on specific lines where useful. End with a short summary.
+            You are reviewing this pull request. Be terse and highly
+            selective: only comment on things that genuinely matter. Skip
+            style nits, naming preferences, and minor opinions.
+
+            Focus on:
+            - Bugs and incorrect logic
+            - Security issues
+            - Inconsistencies with repo conventions (CLAUDE.md)
+            - Missing test coverage of changed behaviour
+
+            Steps:
+            1. Read CLAUDE.md to learn the project's conventions.
+            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to
+               see the changes.
+            3. For each real issue, call
+               `mcp__github_inline_comment__create_inline_comment` with the
+               file, line, and a one-sentence explanation. Cap at 5 inline
+               comments. If there are no real issues, leave none.
+            4. Post one summary comment with
+               `gh pr comment ${{ github.event.pull_request.number }} --body "..."`
+               — overall assessment in 1–3 sentences. Say explicitly if no
+               issues were found.
+
             Do not approve or block — only comment.

--- a/.github/workflows/ml-review.yml
+++ b/.github/workflows/ml-review.yml
@@ -31,17 +31,37 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-opus-4-7'
+          claude_args: >-
+            --model claude-opus-4-7
+            --max-turns 20
+            --allowedTools "Bash(gh:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
           prompt: |
-            You are reviewing a pull request that touches ML / analysis code.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Use the ml-reviewer subagent defined in .claude/agents/ml-reviewer.md.
+            You are reviewing a PR that touches ML / analysis code. Use the
+            ml-reviewer subagent defined in .claude/agents/ml-reviewer.md
+            as your style guide. Be selective — only flag real
+            methodological issues, not style preferences.
+
             Focus on:
             - Statistical assumptions (GMM, PCA, Mahalanobis, Pearson r)
             - Parameter choices (K range, n_init, ΔBIC floor, posterior 0.7, χ² 0.99)
             - Reproducibility and edge cases (tiny cohorts, all-NaN markers)
             - Whether user-facing methodology copy matches the code
 
-            Leave inline comments at `path:line`. End with the structured output
-            format described in the subagent definition (highest-priority issues,
-            improvements, documentation gaps, what's done well).
+            Steps:
+            1. Read CLAUDE.md and .claude/agents/ml-reviewer.md.
+            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to
+               see the changes.
+            3. For each real methodological issue, call
+               `mcp__github_inline_comment__create_inline_comment` with the
+               file, line, and a paragraph-level explanation. Cap at 5
+               inline comments.
+            4. Post one summary comment with
+               `gh pr comment ${{ github.event.pull_request.number }} --body "..."`
+               using the structured output described in the agent definition
+               (highest-priority issues, improvements, documentation gaps,
+               what's done well).
+
+            Do not approve or block — only comment.


### PR DESCRIPTION
## Summary
- Previous setup ran Claude (16 turns, 3m, ~$0.39 equiv on PR #13) but produced zero comments — `permission_denials_count: 6` and `No buffered inline comments`. The inline-comment MCP tool wasn't in the allowed-tools list, and the prompt didn't direct Claude to use it.
- Adds `--allowedTools "Bash(gh:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"` and `--max-turns N` to both workflows.
- Rewrites the prompts: pass `REPO` + `PR NUMBER`, name the MCP tool explicitly, cap inline comments at 5, ask for one summary comment via `gh pr comment`, and instruct Claude to be selective (no style nits).
- Switches the general review to **Haiku 4.5** (~3× cheaper than Sonnet 4.6 for routine code review). ML review stays on **Opus 4.7** per CLAUDE.md design intent — its paths filter limits run frequency.

## Caveat — this PR can't test itself
Anthropic's API requires the workflow file on the PR to match the version on the default branch (security against malicious workflow injection). The review on this PR will run with the *old* workflow from main, so expect the same "no comments" outcome here.

To validate the fix:
1. Merge this PR.
2. Push any commit on PR #13 (or close/reopen it) so its checks re-run against the new main.
3. Look for Claude inline comments + one summary comment on PR #13.

## Test plan
- [ ] After merge: the next PR review run (e.g. on PR #13) posts at least one inline comment via `mcp__github_inline_comment__create_inline_comment`, OR posts a summary comment stating no issues were found.
- [ ] Run cost (visible in run log as `total_cost_usd`) is roughly 3× lower than the Sonnet baseline of ~$0.39.
- [ ] No `permission_denials_count` increase in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)