### PR TITLE
Add per-marker GMM worked example (Groups tab)

### DIFF
--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -863,6 +863,31 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
 .methodology-list li:last-child { margin-bottom: 0; }
 .methodology-list strong { color: var(--ink); font-weight: 600; }
 
+.methodology-example {
+  margin: 1.4rem 0 1.6rem;
+  padding: 1rem 1.15rem 0.6rem;
+  background: var(--accent-50);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+}
+
+.methodology-example__label {
+  color: var(--accent);
+  margin-bottom: 0.55rem;
+}
+
+.methodology-example .t-body,
+.methodology-example .methodology-list {
+  font-size: 0.88rem;
+}
+
+.methodology-example__foot {
+  margin-top: 0.6rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--accent-100);
+  font-size: 0.78rem;
+}
+
 body.methodology-drawer-open { overflow: hidden; }
 
 @media (max-width: 640px) {

--- a/web/templates/partials/_methodology_drawer.html
+++ b/web/templates/partials/_methodology_drawer.html
@@ -75,6 +75,73 @@
           visually but do not drive the labels themselves.
         </p>
 
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Worked example</p>
+
+          <p class="t-body"><strong>The data.</strong>
+            Eight fictional fasting-glucose readings (mmol/L):
+            <code>4.8, 5.1, 5.2, 5.4, 7.9, 8.1, 8.3, 8.6</code>. n = 8.
+          </p>
+
+          <p class="t-body"><strong>1. Fit K = 1.</strong>
+            One Gaussian over all eight points:
+            µ = 6.675, σ = 1.568. Free parameters k = 2 (µ, σ²).
+            log&thinsp;L = &minus;14.95.
+            BIC<sub>1</sub> = &minus;2·(&minus;14.95) + 2·log(8)
+            = 29.90 + 4.16 = <strong>34.06</strong>.
+          </p>
+
+          <p class="t-body"><strong>2. Fit K = 2.</strong>
+            With well-separated points, EM converges to:
+          </p>
+          <ul class="methodology-list">
+            <li>Group 1: µ<sub>1</sub> = 5.125, σ<sub>1</sub> = 0.217, w<sub>1</sub> = 0.500</li>
+            <li>Group 2: µ<sub>2</sub> = 8.225, σ<sub>2</sub> = 0.259, w<sub>2</sub> = 0.500</li>
+          </ul>
+          <p class="t-body">
+            Free parameters k = 5 (two means, two variances, one mixing
+            weight; the second weight is fixed by 1 &minus; w<sub>1</sub>).
+            log&thinsp;L = &minus;5.37.
+            BIC<sub>2</sub> = &minus;2·(&minus;5.37) + 5·log(8)
+            = 10.73 + 10.40 = <strong>21.13</strong>.
+          </p>
+
+          <p class="t-body"><strong>3. Apply the rule.</strong>
+            ΔBIC = 34.06 &minus; 21.13 = <strong>12.93</strong>.
+            12.93 &ge; 6, so we adopt K = 2.
+          </p>
+
+          <p class="t-body"><strong>4. Label a new test.</strong>
+            For a hypothetical reading at x = 6.5 mmol/L the weighted
+            component densities are:
+          </p>
+          <ul class="methodology-list">
+            <li>w<sub>1</sub>·N(6.5 | 5.125, 0.217) &approx; 1.6 × 10<sup>&minus;9</sup></li>
+            <li>w<sub>2</sub>·N(6.5 | 8.225, 0.259) &approx; 1.7 × 10<sup>&minus;10</sup></li>
+          </ul>
+          <p class="t-body">
+            The posterior is the ratio:
+            P(Group 1 | x = 6.5) &approx; <strong>0.91</strong>,
+            P(Group 2 | x = 6.5) &approx; <strong>0.09</strong>.
+            The new test is labelled Group 1.
+          </p>
+
+          <p class="t-body">
+            For a dataset point well inside its cluster (e.g. x = 5.4),
+            the posterior is decisive: P(Group 1 | x = 5.4) &approx; 1.0
+            to six decimal places. Tight, separated clusters give
+            confident assignments; values near the cross-over between
+            components produce intermediate posteriors and flag boundary
+            cases on the <strong>Outliers</strong> tab.
+          </p>
+
+          <p class="t-meta methodology-example__foot">
+            Numbers above match
+            <code>sklearn.mixture.GaussianMixture(n_components=K, n_init=5, random_state=42)</code>
+            fit to the eight values.
+          </p>
+        </div>
+
         <p class="t-body"><strong>Assumptions and limitations.</strong></p>
         <ul class="methodology-list">
           <li>Each marker is treated as 1-dimensional and independent of the others (the Clusters tab handles the multivariate case).</li>


### PR DESCRIPTION
## Summary
- Adds a "Worked example" callout to the per-marker GMM section of the methodology drawer (the body of issue #9).
- Eight fictional fasting-glucose readings (4.8, 5.1, 5.2, 5.4, 7.9, 8.1, 8.3, 8.6 mmol/L) walked through the full pipeline: K=1 fit, K=2 fit, both BIC scores, ΔBIC vs the 6-unit floor, and posteriors at a borderline x=6.5 and an in-cluster x=5.4.
- Every quoted number was recomputed against `sklearn.mixture.GaussianMixture(n_init=5, random_state=42)` and independently verified by the `ml-reviewer` agent — see test plan.
- Adds a small `.methodology-example` callout style (accent-tinted background, left-border accent) to be reused by #10/#11/#12.

Closes #9

## Test plan
- [x] `python -m pytest` passes (199/199).
- [x] `ml-reviewer` agent ran a parallel sklearn fit; all numbers match to the quoted precision. No methodological errors flagged.
- [ ] Open the Groups tab, click "How this works", scroll to the GMM section — the worked example renders inside an accent-bordered callout below the existing methodology copy.
- [ ] At narrow widths (mobile breakpoint) the callout still reads cleanly.

## Verified figures
| Quantity | Value | sklearn |
|---|---|---|
| K=1 µ, σ | 6.675, 1.568 | matches |
| log L₁ | −14.95 | matches |
| BIC₁ | 34.06 | matches |
| K=2 µ₁, σ₁, w₁ | 5.125, 0.217, 0.500 | matches |
| K=2 µ₂, σ₂, w₂ | 8.225, 0.259, 0.500 | matches |
| log L₂ | −5.37 | matches |
| BIC₂ | 21.13 | matches |
| ΔBIC | 12.93 | matches |
| P(G1 \| x=6.5) | 0.91 | matches (0.9054) |
| P(G1 \| x=5.4) | ≈1.0 | matches (1.000000 to 6 dp) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)