### PR TITLE
Add population GMM worked example (Clusters tab)

### DIFF
--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -888,6 +888,36 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
   font-size: 0.78rem;
 }
 
+.methodology-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.83rem;
+  margin: 0.6rem 0 0.9rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.methodology-table thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--ink-2);
+  padding: 0.35rem 0.55rem;
+  border-bottom: 1px solid var(--accent-100);
+}
+
+.methodology-table tbody td {
+  padding: 0.3rem 0.55rem;
+  color: var(--ink-2);
+  border-bottom: 1px solid var(--accent-100);
+}
+
+.methodology-table tbody tr:last-child td { border-bottom: 0; }
+
+.methodology-table tbody td:first-child,
+.methodology-table thead th:first-child {
+  font-weight: 600;
+  color: var(--ink);
+}
+
 body.methodology-drawer-open { overflow: hidden; }
 
 @media (max-width: 640px) {

--- a/web/templates/partials/_methodology_drawer.html
+++ b/web/templates/partials/_methodology_drawer.html
@@ -182,6 +182,173 @@
           to different clusters if they differ on axes that aren't shown.
         </p>
 
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Worked example</p>
+
+          <p class="t-body"><strong>The data.</strong>
+            Six fictional blood tests across four markers (mmol/L for Glucose
+            and lipids, % for HbA1c). T3's HDL is missing &mdash; we'll watch
+            how that flows through.
+          </p>
+
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Test</th><th>Glucose</th><th>HDL</th><th>HbA1c</th><th>LDL</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>T1</td><td>4.8</td><td>1.5</td><td>5.0</td><td>2.4</td></tr>
+              <tr><td>T2</td><td>5.0</td><td>1.5</td><td>5.1</td><td>2.5</td></tr>
+              <tr><td>T3</td><td>5.2</td><td>&mdash;</td><td>5.0</td><td>2.6</td></tr>
+              <tr><td>T4</td><td>7.8</td><td>1.5</td><td>6.4</td><td>3.9</td></tr>
+              <tr><td>T5</td><td>8.0</td><td>1.6</td><td>6.5</td><td>4.0</td></tr>
+              <tr><td>T6</td><td>8.2</td><td>1.5</td><td>6.5</td><td>4.1</td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body"><strong>1. Long &rarr; wide pivot.</strong>
+            Long input (one row per (test, marker) tuple) becomes the 6 &times; 4
+            grid above.
+          </p>
+
+          <p class="t-body"><strong>2. Drop columns with &gt; 50% missing.</strong>
+            For n = 6 the threshold is 3 non-missing values per column. HDL has
+            5/6 non-missing, so all four markers are kept.
+          </p>
+
+          <p class="t-body"><strong>3. Median-impute.</strong>
+            Column medians (computed over non-missing values): Glucose 6.50,
+            HDL 1.50, HbA1c 5.75, LDL 3.25. T3's HDL becomes 1.50.
+          </p>
+
+          <p class="t-body"><strong>4. Standardise.</strong>
+            Each column re-centred to mean 0, variance 1 (using N, not N&minus;1):
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Test</th><th>Glucose</th><th>HDL</th><th>HbA1c</th><th>LDL</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>T1</td><td>&minus;1.127</td><td>&minus;0.447</td><td>&minus;1.044</td><td>&minus;1.127</td></tr>
+              <tr><td>T2</td><td>&minus;0.994</td><td>&minus;0.447</td><td>&minus;0.905</td><td>&minus;0.994</td></tr>
+              <tr><td>T3</td><td>&minus;0.862</td><td>&minus;0.447</td><td>&minus;1.044</td><td>&minus;0.862</td></tr>
+              <tr><td>T4</td><td>+0.862</td><td>&minus;0.447</td><td>+0.905</td><td>+0.862</td></tr>
+              <tr><td>T5</td><td>+0.994</td><td>+2.236</td><td>+1.044</td><td>+0.994</td></tr>
+              <tr><td>T6</td><td>+1.127</td><td>&minus;0.447</td><td>+1.044</td><td>+1.127</td></tr>
+            </tbody>
+          </table>
+          <p class="t-body">
+            HDL is near-constant in the raw data, so T5's lone 1.6 standardises
+            to z = +2.236 &mdash; a sole outlier in an otherwise quiet column.
+          </p>
+
+          <p class="t-body"><strong>5. PCA.</strong>
+            Fit <code>min(n &minus; 1, p) = min(5, 4) = 4</code> components.
+            Explained variance:
+          </p>
+          <ul class="methodology-list">
+            <li>PC1: 81.6% (cumulative 81.6%)</li>
+            <li>PC2: 18.2% (cumulative 99.9%)</li>
+            <li>PC3: 0.2%</li>
+            <li>PC4: ~0.0%</li>
+          </ul>
+          <p class="t-body">
+            PC1 alone exceeds the 80% threshold, so <code>n_for_80 = 1</code>.
+            The 2-D floor (<code>n_cluster_dims = max(2, n_for_80) = 2</code>)
+            keeps a second component anyway. PC1 captures the bulk metabolic
+            story; PC2 captures T5's HDL anomaly.
+          </p>
+
+          <p class="t-body">
+            The 2-D scores fed into clustering:
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Test</th><th>PC1</th><th>PC2</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>T1</td><td>&minus;1.945</td><td>+0.201</td></tr>
+              <tr><td>T2</td><td>&minus;1.725</td><td>+0.125</td></tr>
+              <tr><td>T3</td><td>&minus;1.656</td><td>+0.096</td></tr>
+              <tr><td>T4</td><td>+1.288</td><td>&minus;0.917</td></tr>
+              <tr><td>T5</td><td>+2.386</td><td>+1.542</td></tr>
+              <tr><td>T6</td><td>+1.653</td><td>&minus;1.046</td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body"><strong>6. GMM, diagonal covariance.</strong>
+            Fit K = 1 and K = 2 in the 2-D PCA space (sample-size cap on the
+            K range is <code>max(2, min(5, 6 // 25)) = 2</code>, so only K = 1
+            and K = 2 are searched):
+          </p>
+          <ul class="methodology-list">
+            <li>K = 1: log&thinsp;L = &minus;19.63, BIC = <strong>46.43</strong></li>
+            <li>K = 2: log&thinsp;L = &minus;3.74, BIC = <strong>23.60</strong></li>
+          </ul>
+          <p class="t-body">
+            ΔBIC = 46.43 &minus; 23.60 = <strong>22.83</strong> &mdash; well past
+            the 6-unit floor, so K = 2 is adopted. Sorted cluster parameters:
+          </p>
+          <ul class="methodology-list">
+            <li>Group 1: µ = (&minus;1.776, +0.141), σ² = (0.015, 0.002), w = 0.500 &mdash; tests T1, T2, T3</li>
+            <li>Group 2: µ = (+1.776, &minus;0.141), σ² = (0.208, 1.418), w = 0.500 &mdash; tests T4, T5, T6</li>
+          </ul>
+
+          <p class="t-body"><strong>7. Posterior + Mahalanobis² for T5.</strong>
+            T5 lies firmly in Group 2 on PC1 but is far above the mean on PC2.
+            The posterior P(Group 2 | T5) is still &approx; 1.000 to six decimal
+            places &mdash; PC1 carries 81.6% of the variance and dominates the
+            soft assignment.
+          </p>
+          <p class="t-body">
+            Mahalanobis² to Group 2's mean (with diagonal covariance, this is
+            just Σ (xᵢ &minus; µᵢ)² / σᵢ²):
+          </p>
+          <ul class="methodology-list">
+            <li>PC1 term: (2.386 &minus; 1.776)² / 0.208 = 0.372 / 0.208 &approx; 1.79</li>
+            <li>PC2 term: (1.542 &minus; (&minus;0.141))² / 1.418 = 2.832 / 1.418 &approx; 2.00</li>
+            <li>Sum &approx; <strong>3.78</strong></li>
+          </ul>
+          <p class="t-body">
+            The χ² critical value at p = 0.01 with df = 2 is 9.21, so T5 is
+            <em>not</em> flagged as a multivariate outlier &mdash; Group 2's
+            elevated PC2 variance (1.418) absorbs the anomaly precisely because
+            the cluster is doing the right thing: modelling the within-group
+            spread. This is why the Outliers tab uses the fitted model rather
+            than a fixed distance threshold.
+          </p>
+
+          <p class="t-body"><strong>Why diagonal covariance?</strong>
+            For K = 2, free-parameter counts grow steeply with full covariance:
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Dimensions</th><th>Diagonal</th><th>Full</th><th>Δ</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>2 (this toy fit)</td><td>9</td><td>11</td><td>+2</td></tr>
+              <tr><td>5</td><td>21</td><td>41</td><td>+20</td></tr>
+              <tr><td>10 (~ demo cohort scale)</td><td>41</td><td>131</td><td>+90</td></tr>
+            </tbody>
+          </table>
+          <p class="t-body">
+            Counts come from K·D means + K·D variances (diagonal) or
+            K·D(D+1)/2 covariance entries (full), plus K&minus;1 mixing
+            weights. Each extra parameter is penalised by <code>k · log(n)</code>
+            in BIC. In 10-D space full covariance adds ~90 free parameters
+            per K = 2 model; on a cohort of n = 80 that's an extra penalty
+            of 90 · log(80) &approx; 394 BIC units. Real two-cluster structure
+            can't beat that penalty on small cohorts, so full-covariance K = 2
+            systematically loses to K = 1. Diagonal covariance restores BIC's
+            ability to find genuine structure when n &lt; ~125.
+          </p>
+
+          <p class="t-meta methodology-example__foot">
+            All numbers above are the exact output of
+            <code>analyse_population()</code> on this toy dataset:
+            <code>StandardScaler → PCA(random_state=42) → GaussianMixture(covariance_type='diag', n_init=5, random_state=42)</code>.
+          </p>
+        </div>
+
         <p class="t-body"><strong>Assumptions and limitations.</strong></p>
         <ul class="methodology-list">
           <li>PCA assumes the structure in the data is approximately linear.</li>


### PR DESCRIPTION
## Summary
- Adds a "Worked example" callout to the Population clustering section of the methodology drawer (body of issue #10).
- Six fictional tests × four markers, walked through all seven pipeline steps: wide pivot → drop >50% missing → median impute → standardise → PCA → GMM(diag) → posterior + Mahalanobis².
- T3's HDL is missing, so step 3 has a real imputation to show. T5's HDL is 1.6 in an otherwise 1.5 column — gives a clean visual outlier in PC2 to motivate the Mahalanobis² walk-through.
- Every number was generated by running the actual `analyse_population()` from `analysis.py` on the toy dataset. The `ml-reviewer` agent ran a parallel verification and caught two parameter-count errors in the diag-vs-full table; both fixed in this PR (D=5: 33→41, D=10: 111→131, with downstream BIC penalty 307→394).
- Adds a small `.methodology-table` style (reused by #11/#12).

Closes #10

## Test plan
- [x] `python -m pytest` passes (199/199).
- [x] `ml-reviewer` re-ran `analyse_population()` against the toy data and confirmed every quoted number except the two parameter-count entries it flagged — those have been corrected.
- [ ] Open the Clusters tab, click "How this works", scroll to the Population clustering section — the worked example renders below "The 2-D scatter" paragraph, with three tables (raw data, standardised z-scores, 2-D PCA scores) and the diag-vs-full parameter-count comparison.
- [ ] Tables read clearly at the mobile breakpoint.

## Verified figures (post-fix)
| Quantity | Value | analyse_population() |
|---|---|---|
| K=1 BIC | 46.43 | matches |
| K=2 BIC | 23.60 | matches |
| ΔBIC | 22.83 | matches |
| PC1 var ratio | 81.6% | matches |
| PC2 var ratio | 18.2% | matches |
| T5 P(Group 2) | ≈1.000000 | matches |
| T5 Mahalanobis² | 3.78 | matches (PC1 term 1.79, PC2 term 2.00) |
| χ² df=2 @ p=0.01 | 9.21 | matches |
| 10-D full params (K=2) | 131 | matches (was 111, corrected) |
| 10-D diag params (K=2) | 41 | matches |

🤖 Generated with [Claude Code](https://claude.com/claude-code)