### PR TITLE
Add outlier flagging worked example (Outliers tab)

### DIFF
--- a/web/templates/partials/_methodology_drawer.html
+++ b/web/templates/partials/_methodology_drawer.html
@@ -394,6 +394,111 @@
           the model is least sure about appear first.
         </p>
 
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Worked example &mdash; boundary case</p>
+
+          <p class="t-body">
+            Suppose a K = 3 cluster model assigned a test T<sub>b</sub> the
+            following posterior probability vector:
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Cluster</th><th>Posterior</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Cluster 1</td><td>0.55</td></tr>
+              <tr><td>Cluster 2</td><td>0.40</td></tr>
+              <tr><td>Cluster 3</td><td>0.05</td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body">
+            The probabilities sum to 1.00. The hard label is
+            <code>argmax</code> &rarr; Cluster 1. The maximum posterior is
+            0.55, which is below the 0.7 threshold, so T<sub>b</sub> is
+            <strong>flagged as a boundary case</strong>.
+          </p>
+
+          <p class="t-body">
+            The "Why investigate" line is built from the top two posteriors:
+          </p>
+          <ul class="methodology-list">
+            <li>55% Cluster 1 · 40% Cluster 2</li>
+          </ul>
+          <p class="t-body">
+            The third cluster is omitted (only the two competing components
+            matter for the investigation prompt). Confidence in the table is
+            <code>round(0.55 · 100) = 55%</code>.
+          </p>
+        </div>
+
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Worked example &mdash; multivariate outlier</p>
+
+          <p class="t-body">
+            Now consider a different test T<sub>o</sub> that <em>does</em>
+            land confidently in a cluster (max posterior &gt; 0.7, so the
+            boundary rule does not flag it). Suppose the cluster model
+            kept three principal components and assigned T<sub>o</sub> to
+            Cluster 1, with:
+          </p>
+          <ul class="methodology-list">
+            <li>T<sub>o</sub> in PCA-reduced space: x = (4.5, &minus;2.0, 1.5)</li>
+            <li>Cluster 1 mean: µ = (1.5, &minus;0.5, 0.5)</li>
+            <li>Cluster 1 diagonal covariance: σ² = (0.6, 0.4, 0.5)</li>
+          </ul>
+
+          <p class="t-body">
+            With diagonal covariance, the squared Mahalanobis distance reduces
+            to a sum of squared z-scores:
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>Axis</th><th>(xᵢ &minus; µᵢ)²</th><th>÷ σᵢ²</th><th>Contribution</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>PC1</td><td>(3.0)² = 9.00</td><td>÷ 0.6</td><td>15.00</td></tr>
+              <tr><td>PC2</td><td>(&minus;1.5)² = 2.25</td><td>÷ 0.4</td><td>5.625</td></tr>
+              <tr><td>PC3</td><td>(1.0)² = 1.00</td><td>÷ 0.5</td><td>2.00</td></tr>
+              <tr><td>Sum</td><td colspan="2"></td><td><strong>22.625</strong></td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body">
+            The χ² critical value at p = 0.01 with df = 3 is
+            <code>scipy.stats.chi2.ppf(0.99, df=3) &approx; 11.345</code>.
+            Since 22.625 &gt; 11.345, T<sub>o</sub> is
+            <strong>flagged as a multivariate outlier</strong>: under the
+            assumed Gaussian-mixture model, only ~1% of tests should sit this
+            far from their assigned cluster's mean by chance.
+          </p>
+
+          <p class="t-body">
+            PC1 dominates (15.00 of the 22.625), so T<sub>o</sub>'s anomaly
+            is concentrated on the most explanatory axis &mdash; if PC1
+            captured, say, an overall metabolic-load score, this test is
+            unusually far from its cluster on that axis.
+          </p>
+        </div>
+
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Why the old 5% rule was retired</p>
+
+          <p class="t-body">
+            Previously the Outliers tab flagged the tests in the bottom 5%
+            of log-likelihood within each cluster. That rule
+            <strong>always</strong> flags ~5% of the cohort by construction:
+            on a uniform cohort with no genuine outliers it still surfaces
+            five of every hundred tests, which is misleading. The χ² rule
+            above is an <strong>absolute</strong> threshold &mdash; if no
+            test is genuinely unusual, none are flagged. On a cohort with
+            many genuine outliers (e.g. heavy-tailed marker distributions),
+            it flags more than 1%; on a clean Gaussian cohort, it flags
+            close to 1%; on a uniform cohort with no outliers, it flags
+            zero.
+          </p>
+        </div>
+
         <p class="t-body"><strong>Assumptions and limitations.</strong></p>
         <ul class="methodology-list">
           <li>The χ² threshold is calibrated under the Gaussian-mixture assumption. If a cluster's true within-cluster distribution is non-Gaussian (heavy-tailed, skewed), expected outlier rates may differ from the nominal 1%.</li>


### PR DESCRIPTION
## Summary
- Three callouts in the Outliers section of the methodology drawer (body of issue #11):
  1. **Boundary case** — a K=3 posterior vector (0.55, 0.40, 0.05) walked through: max < 0.7 triggers the flag, hard label is `argmax`, "Why investigate" picks the top two competing clusters, Confidence is `round(max · 100) = 55%`.
  2. **Multivariate outlier** — a hypothetical test in 3-PC reduced space (x = (4.5, −2.0, 1.5); cluster µ = (1.5, −0.5, 0.5); σ² = (0.6, 0.4, 0.5)). Per-PC squared-z contributions: 15.00 + 5.625 + 2.00 = 22.625, compared against `scipy.stats.chi2.ppf(0.99, df=3) ≈ 11.345` → flagged. Shows PC1 dominates the deviation.
  3. **Why the old 5% rule was retired** — short explanatory note that the previous bottom-5%-of-log-likelihood rule always flagged ~5% by construction, while the χ² rule is absolute.
- `ml-reviewer` verified every claim against both the math and the actual `_investigate_context` code (`< 0.7` strict, top-two-cluster formatting, `int(round(max_post * 100))` for Confidence, diagonal-covariance Mahalanobis² formula in `analysis.py`). No bugs found this round.

Closes #11

## Test plan
- [x] `python -m pytest` passes (199/199).
- [x] `ml-reviewer` audit: all numbers and code-to-copy alignment verified.
- [ ] Open the Outliers tab, click "How this works", scroll to the Outlier flagging section — three callouts render below the "Confidence and sorting" paragraph: boundary case, multivariate outlier, retired-rule note.
- [ ] Per-PC Mahalanobis² breakdown table renders cleanly (4 columns: Axis, (xᵢ−µᵢ)², ÷ σᵢ², Contribution).

## Verified figures
| Quantity | Value | Verified |
|---|---|---|
| Boundary posterior max | 0.55 | < 0.7 → flagged |
| "Why investigate" output | `55% Cluster 1 · 40% Cluster 2` | matches code |
| Confidence | 55% | `int(round(0.55·100))` |
| Mahalanobis² PC1 | 15.00 | `(3.0)²/0.6` |
| Mahalanobis² PC2 | 5.625 | `(−1.5)²/0.4` |
| Mahalanobis² PC3 | 2.00 | `(1.0)²/0.5` |
| Sum d² | 22.625 | > threshold → flagged |
| χ²(0.99, df=3) | 11.345 | `scipy.stats.chi2.ppf` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)