### PR TITLE
Add correlations worked example (Correlations tab)

### DIFF
--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -913,9 +913,27 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
 .methodology-table tbody tr:last-child td { border-bottom: 0; }
 
 .methodology-table tbody td:first-child,
-.methodology-table thead th:first-child {
+.methodology-table thead th:first-child,
+.methodology-table tbody th {
   font-weight: 600;
   color: var(--ink);
+}
+
+.methodology-table tbody th {
+  text-align: left;
+  padding: 0.3rem 0.55rem;
+  border-bottom: 1px solid var(--accent-100);
+}
+
+.methodology-example__eq {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.83rem;
+  background: var(--bg);
+  padding: 0.5rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid var(--accent-100);
+  margin: 0.4rem 0 0.8rem;
+  overflow-x: auto;
 }
 
 body.methodology-drawer-open { overflow: hidden; }

--- a/web/templates/partials/_methodology_drawer.html
+++ b/web/templates/partials/_methodology_drawer.html
@@ -532,6 +532,119 @@
           input</strong> &mdash; they are not used in the correlation calculation.
         </p>
 
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Worked example &mdash; Pearson r</p>
+
+          <p class="t-body"><strong>The data.</strong>
+            Ten fictional paired readings of Glucose (mmol/L) and HbA1c (%),
+            two markers expected to move together:
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>i</th><th>Glucose (x)</th><th>HbA1c (y)</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>1</td><td>4.8</td><td>5.1</td></tr>
+              <tr><td>2</td><td>5.1</td><td>5.4</td></tr>
+              <tr><td>3</td><td>5.3</td><td>5.1</td></tr>
+              <tr><td>4</td><td>5.6</td><td>5.5</td></tr>
+              <tr><td>5</td><td>5.9</td><td>5.3</td></tr>
+              <tr><td>6</td><td>6.4</td><td>5.9</td></tr>
+              <tr><td>7</td><td>6.8</td><td>5.8</td></tr>
+              <tr><td>8</td><td>7.2</td><td>6.4</td></tr>
+              <tr><td>9</td><td>7.8</td><td>6.3</td></tr>
+              <tr><td>10</td><td>8.5</td><td>6.9</td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body"><strong>1. Means.</strong>
+            x̄ = 63.4 / 10 = <strong>6.340</strong>,
+            ȳ = 57.7 / 10 = <strong>5.770</strong>.
+          </p>
+
+          <p class="t-body"><strong>2. Deviations from the means.</strong></p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>i</th><th>dx = x &minus; x̄</th><th>dy = y &minus; ȳ</th><th>dx · dy</th><th>dx²</th><th>dy²</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>1</td><td>&minus;1.54</td><td>&minus;0.67</td><td>+1.0318</td><td>2.3716</td><td>0.4489</td></tr>
+              <tr><td>2</td><td>&minus;1.24</td><td>&minus;0.37</td><td>+0.4588</td><td>1.5376</td><td>0.1369</td></tr>
+              <tr><td>3</td><td>&minus;1.04</td><td>&minus;0.67</td><td>+0.6968</td><td>1.0816</td><td>0.4489</td></tr>
+              <tr><td>4</td><td>&minus;0.74</td><td>&minus;0.27</td><td>+0.1998</td><td>0.5476</td><td>0.0729</td></tr>
+              <tr><td>5</td><td>&minus;0.44</td><td>&minus;0.47</td><td>+0.2068</td><td>0.1936</td><td>0.2209</td></tr>
+              <tr><td>6</td><td>+0.06</td><td>+0.13</td><td>+0.0078</td><td>0.0036</td><td>0.0169</td></tr>
+              <tr><td>7</td><td>+0.46</td><td>+0.03</td><td>+0.0138</td><td>0.2116</td><td>0.0009</td></tr>
+              <tr><td>8</td><td>+0.86</td><td>+0.63</td><td>+0.5418</td><td>0.7396</td><td>0.3969</td></tr>
+              <tr><td>9</td><td>+1.46</td><td>+0.53</td><td>+0.7738</td><td>2.1316</td><td>0.2809</td></tr>
+              <tr><td>10</td><td>+2.16</td><td>+1.13</td><td>+2.4408</td><td>4.6656</td><td>1.2769</td></tr>
+              <tr><td>Σ</td><td></td><td></td><td><strong>6.3720</strong></td><td><strong>13.4840</strong></td><td><strong>3.3010</strong></td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body"><strong>3. The formula.</strong>
+            Pearson's r is the sum of products divided by the geometric
+            mean of the two sums of squares:
+          </p>
+          <p class="t-body methodology-example__eq">
+            r = Σ(dx · dy) / √(Σdx² · Σdy²)
+            = 6.3720 / √(13.4840 · 3.3010)
+            = 6.3720 / √44.5107
+            = 6.3720 / 6.6716
+            = <strong>0.9551</strong>
+          </p>
+
+          <p class="t-body">
+            <code>pandas.DataFrame.corr()</code> on this 10-row pair returns
+            <strong>0.9551</strong> to four decimal places &mdash; identical
+            to the manual derivation.
+          </p>
+        </div>
+
+        <div class="methodology-example">
+          <p class="t-eyebrow methodology-example__label">Counter-example &mdash; what r misses</p>
+
+          <p class="t-body">
+            Consider ten paired readings with a clear non-linear relationship:
+            y = x² (a perfect parabola, skipping x = 0 to keep ten points):
+          </p>
+          <table class="methodology-table">
+            <thead>
+              <tr><th>x</th><td>&minus;5</td><td>&minus;4</td><td>&minus;3</td><td>&minus;2</td><td>&minus;1</td><td>+1</td><td>+2</td><td>+3</td><td>+4</td><td>+5</td></tr>
+            </thead>
+            <tbody>
+              <tr><th>y</th><td>25</td><td>16</td><td>9</td><td>4</td><td>1</td><td>1</td><td>4</td><td>9</td><td>16</td><td>25</td></tr>
+            </tbody>
+          </table>
+
+          <p class="t-body">
+            Pearson r on this pair is <strong>exactly 0.000</strong>: every
+            positive deviation in x is matched by an equal-and-opposite
+            partner, so all the products cancel. The metric reads "no
+            relationship" even though x and y are deterministically tied
+            (knowing x gives you y exactly).
+          </p>
+
+          <p class="t-body">
+            This is the headline caveat of Pearson r: it captures
+            <strong>linear association only</strong>. The pair could be a
+            U-shape, a sine wave, or any non-monotonic curve and r would
+            still register near zero.
+          </p>
+
+          <p class="t-body">
+            <strong>Spearman's rank correlation</strong> would catch
+            <em>monotonic</em> non-linear relationships (e.g. y = e<sup>x</sup>,
+            where y rises with x at an increasing rate &mdash; not a straight
+            line, but order-preserving). Spearman computes Pearson on the
+            ranks rather than the raw values, so any monotonic transform
+            scores r = 1. It does <strong>not</strong> rescue the U-shape
+            above &mdash; that's non-monotonic, and Spearman returns 0 too.
+            For non-monotonic dependence, neither metric is the right tool;
+            visual inspection or distance correlation is.
+          </p>
+        </div>
+
         <p class="t-body"><strong>Assumptions and limitations.</strong></p>
         <ul class="methodology-list">
           <li>Pearson r captures <strong>linear association only</strong>. Non-linear coupling (e.g. U-shaped) will read as weak even when a real relationship exists. Spearman's rank correlation would be more appropriate for monotonic non-linear cases.</li>


### PR DESCRIPTION
## Summary
- Two callouts in the Correlations section of the methodology drawer (body of issue #12):
  1. **Pearson r worked example** — a 10-row paired Glucose/HbA1c dataset walked through means → per-row deviations → products and squared deviations → column sums → final `r = 6.3720 / √44.5107 = 6.3720 / 6.6716 = 0.9551`. Matches `pandas.DataFrame.corr()` to 4 dp.
  2. **U-shape counter-example** — ten points `y = x²` (x ∈ ±1..±5, skipping 0). Pearson r is exactly 0 because positive-x deviations cancel negative-x ones, demonstrating the linear-only caveat. Notes Spearman r = 0 here too (non-monotonic), then contrasts with monotonic non-linear cases like `y = exp(x)` where Spearman = 1.
- `ml-reviewer` ran a parallel computation, verified all 10 rows of deviations + products + squared deviations + column sums + final r against `pandas.DataFrame.corr()` and `scipy.stats.pearsonr` / `spearmanr`. Caught a 4-dp rounding error in the intermediate product (44.5106 → 44.5107) and a misleading `min_periods=10` claim in my callout text — both corrected before commit.
- Adds `tbody <th>` support to `.methodology-table` (used for the row-headered U-shape table) and a `.methodology-example__eq` monospace block for the formula line.

Closes #12

## Note on a pre-existing copy issue (out of scope here)
ml-reviewer also flagged that the **existing** "Library and parameters" paragraph above the new callouts asserts `min_periods=10` is universal, but in `web/main.py:724` (`pair_partial`) the displayed pair only requires `len(wide) >= 4`. The 10-row threshold is only used by `strongest_marker_pair` for the auto-pick. Worth a follow-up either to tighten the code to enforce 10 everywhere, or to soften the methodology copy. Left out of this PR to keep scope tight.

## Test plan
- [x] `python -m pytest` passes (199/199).
- [x] `ml-reviewer` audit: all numbers and the Spearman / monotonic claim verified; rounding and min_periods inaccuracies corrected.
- [ ] Open the Correlations tab, click "How this works", scroll to the Correlations section — two callouts render below "Reference range overlay": the full Pearson r breakdown table (6-column: i, dx, dy, dx·dy, dx², dy² with Σ row) and the U-shape counter-example.
- [ ] Tables read cleanly at the mobile breakpoint.

## Verified figures
| Quantity | Value | Verified |
|---|---|---|
| x̄ Glucose | 6.340 | matches |
| ȳ HbA1c | 5.770 | matches |
| Σ dx·dy | 6.3720 | matches |
| Σ dx² | 13.4840 | matches |
| Σ dy² | 3.3010 | matches |
| Product | 44.5107 | matches (was 44.5106, corrected) |
| √product | 6.6716 | matches |
| r | 0.9551 | matches `pandas.DataFrame.corr()` |
| U-shape Pearson r | 0.0000 | matches |
| U-shape Spearman r | 0.0000 | matches |
| Monotonic Spearman r (y=eˣ) | 1.0000 | matches |

🤖 Generated with [Claude Code](https://claude.com/claude-code)