### PR TITLE
Tune ml-review workflow: bump --max-turns, refresh paths filter

### DIFF
--- a/.github/workflows/ml-review.yml
+++ b/.github/workflows/ml-review.yml
@@ -6,10 +6,11 @@ on:
     paths:
       - 'analysis.py'
       - 'gmm.py'
-      - 'web/main.py'
       - 'parsing.py'
       - 'unit_conversions.py'
       - 'thresholds.py'
+      - 'web/charts.py'
+      - 'web/contexts.py'
       - 'tests/test_analysis.py'
       - 'tests/test_gmm_functions.py'
 
@@ -33,7 +34,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --model claude-opus-4-7
-            --max-turns 20
+            --max-turns 35
             --allowedTools "Bash(gh:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- `--max-turns 20 → 35` so Opus has enough budget for larger diffs (PR #24's ml-review failed at the 20-turn limit).
- Paths filter refreshed to match the post-#21 layout: drop `web/main.py`, add `web/charts.py` and `web/contexts.py`. Other ML files unchanged.

Closes #25

## Test plan
This is config-only; the workflow itself doesn't change. Verification happens on the next two PRs:

- [ ] This PR's `ml-review` job is **skipped** (paths filter excludes `.github/workflows/*`).
- [ ] PR #26 (drawer split, no ML code touched) will also have `ml-review` **skipped**.
- [ ] Any future PR touching `analysis.py`, `gmm.py`, `web/charts.py`, or `web/contexts.py` triggers ml-review and completes within the new 35-turn budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)