### PR TITLE
Add plain-english 'so what' leads to methodology drawer panels

### DIFF
--- a/web/templates/partials/methodology/_clusters.html
+++ b/web/templates/partials/methodology/_clusters.html
@@ -1,5 +1,35 @@
 <h3 class="t-h2 methodology-drawer__section-title">Population clustering (PCA → GMM)</h3>
 
+<p class="t-body"><strong>The point.</strong>
+  Forget one marker at a time &mdash; when you look at <em>every</em>
+  marker together, do these blood tests fall into distinct profiles?
+  A "metabolic-syndrome" profile, a "low-cholesterol-low-glucose"
+  profile, and so on. This view answers whether such profiles actually
+  exist in the cohort, or whether the tests are one continuous blob.
+</p>
+
+<p class="t-body"><strong>What you're looking at.</strong>
+  Each dot is one blood test, plotted by the two most informative
+  combinations of markers (the first two principal components). Each
+  colour is one profile (cluster). Two dots close together = similar
+  across all markers; two far apart = different overall patterns.
+</p>
+
+<p class="t-body"><strong>When it's interesting.</strong>
+  Clean separated colour blobs = the cohort really does contain distinct
+  sub-types. Overlapping colours = soft groupings, still useful but less
+  crisp. One colour = no detectable sub-types at this cohort size.
+</p>
+
+<p class="t-body"><strong>One subtlety.</strong>
+  The clustering happens in a higher-dimensional space than the 2-D
+  chart. Two tests can look adjacent on screen yet belong to different
+  clusters if they differ on an axis that isn't shown.
+</p>
+
+<details class="disclosure">
+  <summary>How it works &mdash; technical detail</summary>
+
 <p class="t-body"><strong>Pipeline.</strong></p>
 <ol class="methodology-list">
   <li>Pivot long-format data to wide (rows = blood tests, columns = markers).</li>
@@ -197,3 +227,5 @@
   <li>The 80% variance threshold is conventional but arbitrary; raising it would use more dimensions and potentially split into more clusters.</li>
   <li>With K up to 5 and small samples (&lt;&nbsp;200 tests) the model has plenty of freedom and may over-cluster. The headline carries a small-sample warning when applicable.</li>
 </ul>
+
+</details>

--- a/web/templates/partials/methodology/_correlations.html
+++ b/web/templates/partials/methodology/_correlations.html
@@ -1,5 +1,34 @@
 <h3 class="t-h2 methodology-drawer__section-title">Correlations</h3>
 
+<p class="t-body"><strong>The point.</strong>
+  When marker X moves, does marker Y move with it? Some pairs are
+  biologically tied &mdash; glucose and HbA1c rise together; HDL and
+  LDL often pull in opposite directions. This view gives you a single
+  number for the strength and direction of that pairing, plus the
+  scatter behind it.
+</p>
+
+<p class="t-body"><strong>What you're looking at.</strong>
+  Each dot is one blood test, plotted by its values for the two
+  selected markers. Colours match the cluster from the Clusters tab
+  &mdash; useful for spotting when a correlation is really driven by
+  one sub-group. The headline number is <strong>r</strong>:
+  <strong>+1</strong> = perfect rising line, <strong>0</strong> = no
+  linear relationship, <strong>&minus;1</strong> = perfect falling line.
+</p>
+
+<p class="t-body"><strong>When it's interesting.</strong>
+  |r|&nbsp;&gt;&nbsp;0.7 = strong, the two markers track each other
+  closely. |r|&nbsp;&asymp;&nbsp;0.3&ndash;0.7 = moderate, a real but
+  noisy link. |r|&nbsp;&lt;&nbsp;0.3 = weak. <strong>Important caveat:</strong>
+  r catches <em>linear</em> trends only &mdash; a U-shape will read near
+  zero even when the markers are clearly tied. The counter-example below
+  shows this in action.
+</p>
+
+<details class="disclosure">
+  <summary>How it works &mdash; technical detail</summary>
+
 <p class="t-body"><strong>Metric.</strong>
   For the selected pair (X, Y) we compute the
   <strong>Pearson correlation coefficient r</strong> across all blood
@@ -141,3 +170,5 @@
   <li>Correlation does not imply causation. Two markers can correlate because they're both driven by a third underlying factor (e.g. liver function affecting several enzymes).</li>
   <li>The "strongest pair" auto-pick is based on |r| alone, not on biological plausibility or statistical significance.</li>
 </ul>
+
+</details>

--- a/web/templates/partials/methodology/_gmm.html
+++ b/web/templates/partials/methodology/_gmm.html
@@ -1,5 +1,30 @@
 <h3 class="t-h2 methodology-drawer__section-title">Per-marker Gaussian mixture model</h3>
 
+<p class="t-body"><strong>The point.</strong>
+  Does this marker split into natural sub-populations, or is it one tight
+  band? Fasting glucose really does form two humps &mdash; a healthy band
+  and a diabetic band. Sodium is one band for almost everyone. This chart
+  shows whichever the data actually contains, with no reference range fed
+  into the model.
+</p>
+
+<p class="t-body"><strong>What you're looking at.</strong>
+  Each coloured curve is one sub-group the model detected. The bars are
+  the raw count of tests at each value. Vertical lines mark where one
+  group hands over to the next. A single curve means no detectable
+  sub-structure for this cohort.
+</p>
+
+<p class="t-body"><strong>When it's interesting.</strong>
+  Two well-separated curves = a genuinely bimodal marker, worth
+  investigating clinically. Overlapping curves with a faint dip = soft
+  sub-populations. One curve = a uniform marker for this cohort, no
+  story to tell.
+</p>
+
+<details class="disclosure">
+  <summary>How it works &mdash; technical detail</summary>
+
 <p class="t-body"><strong>What we fit.</strong>
   A <strong>Gaussian Mixture Model (GMM)</strong> is fit to each marker
   independently. The model assumes the observed values come from a mixture
@@ -112,3 +137,5 @@
   <li>With small samples (&lt;&nbsp;30 tests) the choice between 2 and 3 components can be unstable. Small-sample warnings are surfaced explicitly in the headline.</li>
   <li>The model uses no clinical reference range as input. Reference lines on the chart are added afterwards purely as context.</li>
 </ul>
+
+</details>

--- a/web/templates/partials/methodology/_outliers.html
+++ b/web/templates/partials/methodology/_outliers.html
@@ -1,5 +1,33 @@
 <h3 class="t-h2 methodology-drawer__section-title">Outlier flagging</h3>
 
+<p class="t-body"><strong>The point.</strong>
+  Every blood test gets placed into one of the cluster profiles from
+  the previous tab. Most land squarely inside one. A few don't &mdash;
+  either they're stuck <em>between</em> two profiles, or they're a long
+  way from <em>every</em> profile. Those are the tests worth a second
+  look, and that's what this view surfaces.
+</p>
+
+<p class="t-body"><strong>What you're looking at.</strong>
+  A ranked list of the least-confident tests, with the reason each was
+  flagged. "Boundary case" means the test sits between two clusters
+  &mdash; the model genuinely can't decide. "Multivariate outlier" means
+  the test lands in one cluster but sits unusually far from that
+  cluster's typical pattern, by a model-based distance, not just a
+  single odd marker.
+</p>
+
+<p class="t-body"><strong>When it's interesting.</strong>
+  A short list = most of the cohort fits the cluster profiles cleanly.
+  A long list of <em>boundary cases</em> = your clusters overlap; the
+  profile boundaries are fuzzy. A long list of <em>multivariate
+  outliers</em> = the cohort has heavy tails and the Gaussian model is
+  fighting them. Either way, the listed tests are the ones to start with.
+</p>
+
+<details class="disclosure">
+  <summary>How it works &mdash; technical detail</summary>
+
 <p class="t-body"><strong>Two flagging rules.</strong>
   Both rules use outputs of the cluster model on the Clusters tab &mdash;
   nothing is re-fit here.
@@ -143,3 +171,5 @@
   <li>Both rules inherit the assumptions of the cluster model itself: approximately linear structure (PCA), diagonal within-cluster covariance, and Gaussian-shaped clusters (GMM).</li>
   <li>Diagonal covariance ignores within-cluster correlation between PCs; if real clusters are elongated along non-axis directions, the Mahalanobis distance under-states actual distance and outliers may be missed.</li>
 </ul>
+
+</details>


### PR DESCRIPTION
## Summary

The four methodology drawer panels (Groups, Clusters, Outliers, Correlations) currently open with algorithm vocabulary — *"What we fit. A Gaussian Mixture Model…"*, *"Pipeline. Pivot long-format data…"*, *"Metric. We compute the Pearson correlation coefficient…"* — before saying what the view is **for**. Each panel now leads with three short non-expert paragraphs:

1. **The point** — one sentence answering "so what."
2. **What you're looking at** — mapping chart elements to that point.
3. **When it's interesting** — what a meaningful vs. unremarkable result looks like.

The existing technical content (pipeline, library/parameters, worked examples, assumptions/limitations) is preserved **verbatim** inside a `<details class="disclosure">` wrapper labelled *"How it works — technical detail"*. Power users still get the full derivation; first-time readers get the headline first.

No analysis logic, route handlers, or templates outside `partials/methodology/` were touched. The drawer JS controller and section anchors are unaffected — the lead block sits inside the existing `<section data-mdr-section="…">` wrappers.

## Test plan

- [x] 228 tests pass (`python -m pytest -q`).
- [x] All four panels contain "The point" lead (`curl /` → 4 hits).
- [x] All four panels contain the *How it works — technical detail* disclosure summary (4 hits).
- [x] All five canonical worked-example numbers from #22 / PR #27 still render (22.625, 0.9551, 34.06, 46.43, 22.83).
- [ ] Click through each tab's "How this works" trigger in the browser and confirm the lead renders cleanly above the collapsed disclosure, and that expanding the disclosure shows the unchanged technical content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)