### PR TITLE
Remove unused web-layer symbols

### DIFF
--- a/web/contexts.py
+++ b/web/contexts.py
@@ -316,7 +316,6 @@ def _common(spec: FilterSpec, data: dict) -> dict:
     return {
         "is_demo":         state.is_demo,
         "upload_filename": state.upload_filename,
-        "upload_error":    state.last_upload_error,
         "filters":         spec,
         "filter_qs":       spec.to_query_string(),
         "filtered":        spec.is_active(),

--- a/web/filters.py
+++ b/web/filters.py
@@ -31,9 +31,6 @@ class FilterSpec:
             or len(self.markers) > 0
         )
 
-    def cache_key(self) -> tuple:
-        return (self.age_min, self.age_max, self.markers)
-
     @classmethod
     def from_request(
         cls,

--- a/web/main.py
+++ b/web/main.py
@@ -23,7 +23,7 @@ from web.contexts import (
     _pair_context,
     _population_context,
 )
-from web.filters import FilterSpec, VALID_TABS, _resolve_tab
+from web.filters import FilterSpec, _resolve_tab
 from web.state import (
     MULTI_UNIT_MARKERS,
     _filtered_data,


### PR DESCRIPTION
Part of milestone **Code-quality cleanup & test-safety net** (#3) — issue 1 of 6.

Removes three dead symbols with no consumers:
- `VALID_TABS` import in `web/main.py` (only used inside `web/filters.py`)
- `upload_error` context key in `web/contexts.py` (no template references it; upload errors render inline via the `cohort-error` div)
- `FilterSpec.cache_key()` in `web/filters.py` (never called; `lru_cache` uses the frozen-dataclass hash)

Web layer only — no `demo_cache.pkl` rebake required.

## Verification
- `git grep` confirms no remaining references (the surviving `state.last_upload_error` is the upload-route state field, intentionally kept).
- 233 tests pass.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)