### PR TITLE
Add ruff linting + complexity cap + CI gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,17 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - run: pip install ruff
+      - run: ruff check .
+
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/analysis.py
+++ b/analysis.py
@@ -4,11 +4,11 @@
 
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import StandardScaler
 from sklearn.decomposition import PCA
 from sklearn.mixture import GaussianMixture
+from sklearn.preprocessing import StandardScaler
 
-from gmm import fit_optimal_gmm, sort_gmm, get_boundaries
+from gmm import fit_optimal_gmm, get_boundaries, sort_gmm
 
 
 def analyse_upload(df_long: pd.DataFrame) -> dict:
@@ -61,7 +61,7 @@ def build_labelled_df(df_long: pd.DataFrame, gmm_results: dict) -> pd.DataFrame:
         values = df.loc[mask, "value"].values
         raw = res["gmm"].predict(values.reshape(-1, 1))
         sorted_labels = res["order_inverse"][raw]
-        df.loc[mask, "Group"] = [f"Group {l + 1}" for l in sorted_labels]
+        df.loc[mask, "Group"] = [f"Group {lbl + 1}" for lbl in sorted_labels]
     return df
 
 
@@ -136,7 +136,7 @@ def analyse_population(df_long: pd.DataFrame) -> dict:
 
     z_scores     = pd.DataFrame(X_scaled, index=df_wide.index, columns=df_wide.columns)
     fingerprint  = z_scores.copy()
-    fingerprint["Group"] = [f"Group {l + 1}" for l in labels]
+    fingerprint["Group"] = [f"Group {lbl + 1}" for lbl in labels]
     fingerprint  = fingerprint.groupby("Group").mean().T
 
     return {

--- a/bake_demo.py
+++ b/bake_demo.py
@@ -12,15 +12,17 @@ import pickle
 import time
 from pathlib import Path
 
+from analysis import analyse_population, analyse_upload, build_labelled_df
 from stub_data import generate_stub_data
-from analysis import analyse_upload, analyse_population, build_labelled_df
 
 out = Path(__file__).parent / "demo_cache.pkl"
 
 print("Generating demo data…")
 t0 = time.perf_counter()
 df_long = generate_stub_data()
-print(f"  {len(df_long['patient_id'].unique())} patients, {len(df_long['test_name'].unique())} markers  ({time.perf_counter()-t0:.1f}s)")
+n_pat = len(df_long["patient_id"].unique())
+n_mark = len(df_long["test_name"].unique())
+print(f"  {n_pat} patients, {n_mark} markers  ({time.perf_counter() - t0:.1f}s)")
 
 print("Fitting per-marker GMMs…")
 t1 = time.perf_counter()

--- a/gmm.py
+++ b/gmm.py
@@ -2,9 +2,9 @@
 # Core GMM fitting functions used by analysis.py and bake_demo.py.
 
 import numpy as np
-from sklearn.mixture import GaussianMixture
 from scipy.optimize import brentq
 from scipy.stats import norm as scipy_norm
+from sklearn.mixture import GaussianMixture
 
 
 def fit_optimal_gmm(values: np.ndarray, delta_bic_threshold: float = 6.0) -> tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.ruff]
+# Lint-only configuration (no repo-wide formatter). The codebase is hand-aligned,
+# so we keep a readable 100-col limit on logic and exempt the pure reference-table
+# modules below from line-length.
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+# F  = pyflakes (unused imports/vars — the dead-code class)
+# E,W = pycodestyle errors/warnings
+# I  = import sorting
+# C90 = mccabe complexity (the guard against function bloat)
+select = ["F", "E", "W", "I", "C90"]
+
+[tool.ruff.lint.mccabe]
+# Ratchet: the current worst function scores 7. Cap at 10 so existing code
+# passes and only genuinely new complexity is blocked. Tighten over time.
+max-complexity = 10
+
+[tool.ruff.lint.per-file-ignores]
+# Hand-aligned reference tables — line-length would force pointless re-wrapping.
+"column_map.py" = ["E501"]
+"unit_conversions.py" = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,17 @@ target-version = "py311"
 # C90 = mccabe complexity (the guard against function bloat)
 select = ["F", "E", "W", "I", "C90"]
 
+[tool.ruff.lint.isort]
+# The web package must import before the project-root analysis modules so
+# web/__init__.py (which puts PROJECT_ROOT on sys.path) is unambiguously the
+# first thing to run. Encode that as section order: first-party (web) precedes
+# local-folder (the root modules), so ruff enforces the contract automatically.
+known-first-party = ["web"]
+known-local-folder = [
+    "analysis", "gmm", "parsing", "thresholds",
+    "unit_conversions", "column_map", "stub_data",
+]
+
 [tool.ruff.lint.mccabe]
 # Ratchet: the current worst function scores 7. Cap at 10 so existing code
 # passes and only genuinely new complexity is blocked. Tighten over time.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ scipy
 numpy
 plotly
 pytest
+ruff
 fastapi
 uvicorn[standard]
 jinja2

--- a/stub_data.py
+++ b/stub_data.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 import pandas as pd
+
 from thresholds import THRESHOLDS
 
 # ── Per-marker Gaussian parameters ────────────────────────────────────────────

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,11 +1,16 @@
 import numpy as np
 import pandas as pd
 import pytest
-from stub_data import generate_stub_data
+
 from analysis import (
-    analyse_upload, analyse_population, build_labelled_df,
-    filter_long, most_separated_marker, strongest_marker_pair,
+    analyse_population,
+    analyse_upload,
+    build_labelled_df,
+    filter_long,
+    most_separated_marker,
+    strongest_marker_pair,
 )
+from stub_data import generate_stub_data
 
 
 @pytest.fixture(scope="module")
@@ -153,8 +158,8 @@ def test_uniform_population_reports_k1():
     for i in range(120):
         rows.append({"patient_id": f"P{i}", "age": 40,
                      "test_name": "TSH", "value": float(rng.normal(2.0, 0.3)), "unit": "mIU/L"})
-        rows.append({"patient_id": f"P{i}", "age": 40,
-                     "test_name": "Free T4", "value": float(rng.normal(15.0, 1.5)), "unit": "pmol/L"})
+        rows.append({"patient_id": f"P{i}", "age": 40, "test_name": "Free T4",
+                     "value": float(rng.normal(15.0, 1.5)), "unit": "pmol/L"})
     df = pd.DataFrame(rows)
     result = analyse_population(df)
     assert result["n_clusters"] == 1
@@ -253,7 +258,8 @@ def test_strongest_marker_pair_empty():
 
 def test_strongest_marker_pair_single_marker():
     df = pd.DataFrame([
-        {"patient_id": f"P{i}", "age": 40, "test_name": "TSH", "value": 2.0 + i * 0.1, "unit": "mIU/L"}
+        {"patient_id": f"P{i}", "age": 40, "test_name": "TSH",
+         "value": 2.0 + i * 0.1, "unit": "mIU/L"}
         for i in range(20)
     ])
     assert strongest_marker_pair(df) is None

--- a/tests/test_column_map.py
+++ b/tests/test_column_map.py
@@ -1,4 +1,3 @@
-import pytest
 from column_map import COLUMN_MAP, ID_COLUMN
 from thresholds import THRESHOLDS
 

--- a/tests/test_gmm_functions.py
+++ b/tests/test_gmm_functions.py
@@ -1,8 +1,7 @@
 import numpy as np
-import pytest
 from sklearn.mixture import GaussianMixture
-from gmm import fit_optimal_gmm, sort_gmm, get_boundaries, assign_clusters
 
+from gmm import assign_clusters, fit_optimal_gmm, get_boundaries, sort_gmm
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,6 +1,6 @@
 import pytest
-from thresholds import classify_test, THRESHOLDS
 
+from thresholds import THRESHOLDS, classify_test
 
 # ── Every marker in THRESHOLDS should have required keys ──────────────────────
 

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -1,6 +1,6 @@
 import pytest
-from unit_conversions import to_canonical
 
+from unit_conversions import to_canonical
 
 # ── Testosterone (nmol/L ↔ ng/dL, threshold > 100) ────────────────────────
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -403,8 +403,9 @@ def test_units_set_switches_display_unit() -> None:
     """HbA1C supports multiple units (%, mmol/mol). Setting the alt should
     persist in state.unit_prefs."""
     # Pick a multi-unit marker present in the demo.
-    from unit_conversions import available_units
     from web.state import MULTI_UNIT_MARKERS
+
+    from unit_conversions import available_units
     present = set(state.df_long_full["test_name"].unique())
     candidate = next((m for m in MULTI_UNIT_MARKERS if m in present), None)
     if candidate is None:

--- a/web/charts.py
+++ b/web/charts.py
@@ -15,9 +15,10 @@ import plotly.graph_objects as go
 from plotly.io import to_html as plotly_to_html
 from scipy.stats import norm as scipy_norm
 
+from web.state import _display_unit
+
 from thresholds import THRESHOLDS
 from unit_conversions import from_canonical, transform_for_display
-from web.state import _display_unit
 
 CLUSTER_COLOURS = ["#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B2"]
 CHART_FONT = ("-apple-system, BlinkMacSystemFont, 'Inter', system-ui, "

--- a/web/charts.py
+++ b/web/charts.py
@@ -17,7 +17,6 @@ from scipy.stats import norm as scipy_norm
 
 from thresholds import THRESHOLDS
 from unit_conversions import from_canonical, transform_for_display
-
 from web.state import _display_unit
 
 CLUSTER_COLOURS = ["#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B2"]

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -14,7 +14,6 @@ from scipy.stats import chi2
 
 from analysis import most_separated_marker, strongest_marker_pair
 from unit_conversions import transform_for_display
-
 from web.charts import (
     CLUSTER_COLOURS,
     _heatmap_html,
@@ -29,7 +28,6 @@ from web.state import (
     _units_ui_context,
     state,
 )
-
 
 # ── Marker explorer (Groups tab) ─────────────────────────────────────────────
 
@@ -334,7 +332,9 @@ def _build_tab_ctx(data: dict, tab: str) -> dict:
         return {}
     if tab == "explorer":
         pick = most_separated_marker(data["gmm_results"])
-        available = sorted([t for t in data["gmm_results"] if "error" not in data["gmm_results"][t]])
+        available = sorted(
+            t for t in data["gmm_results"] if "error" not in data["gmm_results"][t]
+        )
         initial = pick[0] if pick else (available[0] if available else None)
         if initial is None:
             return {}

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -12,8 +12,6 @@ import numpy as np
 import pandas as pd
 from scipy.stats import chi2
 
-from analysis import most_separated_marker, strongest_marker_pair
-from unit_conversions import transform_for_display
 from web.charts import (
     CLUSTER_COLOURS,
     _heatmap_html,
@@ -28,6 +26,9 @@ from web.state import (
     _units_ui_context,
     state,
 )
+
+from analysis import most_separated_marker, strongest_marker_pair
+from unit_conversions import transform_for_display
 
 # ── Marker explorer (Groups tab) ─────────────────────────────────────────────
 

--- a/web/main.py
+++ b/web/main.py
@@ -14,11 +14,6 @@ from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from analysis import analyse_population, analyse_upload, build_labelled_df
-from parsing import parse_csv
-from thresholds import THRESHOLDS
-from unit_conversions import available_units
-
 # web.* imports first so web/__init__.py is unambiguously responsible for
 # putting PROJECT_ROOT on sys.path before any project-root module is touched.
 from web.contexts import (
@@ -38,6 +33,11 @@ from web.state import (
     _normalise_age,
     state,
 )
+
+from analysis import analyse_population, analyse_upload, build_labelled_df
+from parsing import parse_csv
+from thresholds import THRESHOLDS
+from unit_conversions import available_units
 
 ROOT = Path(__file__).resolve().parent
 

--- a/web/main.py
+++ b/web/main.py
@@ -14,6 +14,11 @@ from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from analysis import analyse_population, analyse_upload, build_labelled_df
+from parsing import parse_csv
+from thresholds import THRESHOLDS
+from unit_conversions import available_units
+
 # web.* imports first so web/__init__.py is unambiguously responsible for
 # putting PROJECT_ROOT on sys.path before any project-root module is touched.
 from web.contexts import (
@@ -33,11 +38,6 @@ from web.state import (
     _normalise_age,
     state,
 )
-
-from analysis import analyse_population, analyse_upload, build_labelled_df
-from parsing import parse_csv
-from thresholds import THRESHOLDS
-from unit_conversions import available_units
 
 ROOT = Path(__file__).resolve().parent
 

--- a/web/state.py
+++ b/web/state.py
@@ -22,7 +22,6 @@ from analysis import (
 )
 from thresholds import THRESHOLDS
 from unit_conversions import available_units
-
 from web.filters import FilterSpec
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -85,7 +84,10 @@ def _filtered_data_cached(spec: FilterSpec) -> dict:
     n = df_filtered["patient_id"].nunique() if not df_filtered.empty else 0
 
     if n < 4:
-        msg = f"Only {n} blood test{'s' if n != 1 else ''} match the current filters — need at least 4 to run analysis."
+        msg = (
+            f"Only {n} blood test{'s' if n != 1 else ''} match the current filters "
+            "— need at least 4 to run analysis."
+        )
         return {
             "error":       msg,
             "df_long":     df_filtered,
@@ -185,7 +187,11 @@ def _filter_ui_context(spec: FilterSpec) -> dict:
 def _units_ui_context() -> dict:
     """Per-marker display-unit options. Only markers with > 1 supported unit
     AND a value in the current cohort are shown."""
-    present = set(state.df_long_full["test_name"].unique()) if state.df_long_full is not None else set()
+    present = (
+        set(state.df_long_full["test_name"].unique())
+        if state.df_long_full is not None
+        else set()
+    )
     rows: list[dict] = []
     for marker in MULTI_UNIT_MARKERS:
         if marker not in present:

--- a/web/state.py
+++ b/web/state.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import pandas as pd
 
+from web.filters import FilterSpec
+
 from analysis import (
     analyse_population,
     analyse_upload,
@@ -22,7 +24,6 @@ from analysis import (
 )
 from thresholds import THRESHOLDS
 from unit_conversions import available_units
-from web.filters import FilterSpec
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
Part of milestone **Code-quality cleanup & test-safety net** (#3) — issue 3 of 6.

Adds `ruff` to catch the dead-code class going forward and guard against function bloat — the tooling half of the cleanup.

## Config (`pyproject.toml`)
- Rules: `F` (pyflakes), `E`/`W` (pycodestyle), `I` (import sort), `C90` (mccabe).
- `line-length = 100`; per-file `E501` ignore for the two hand-aligned reference-table modules (`column_map.py`, `unit_conversions.py`) so we don't re-wrap data tables.
- `max-complexity = 10` — a **ratchet** just above the current worst function (7), so existing code passes and only new complexity is blocked. Tighten over time.
- **Lint only** — no repo-wide `ruff format` (avoids churn, per the agreed decision).

## Changes to get green
- Autofix: import sorting across modules; removed two unused `pytest` imports.
- Manual: renamed two ambiguous `l` loop vars → `lbl`; wrapped six genuinely long lines.

## CI
- New `lint` job runs `ruff check .` alongside the existing `pytest` job; `ruff` added to `requirements.txt`.

## Verification
- `ruff check .` passes.
- Gate verified: a planted unused import (`F401`) and an 11-branch function (`C901 11 > 10`) are both caught.
- `demo_cache.pkl` unchanged (the rename is cosmetic).
- 233 tests pass.

> Note: an honest limit — linting catches dead *imports* and complexity, not behavioral no-ops or returned-but-unused values. Those are covered by the dead-field PR (#38, merged) and the upcoming behavioral-tests issue (#34).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)