### PR TITLE
Add ruff B (bugbear) + NPY rule sets

### DIFF
--- a/gmm.py
+++ b/gmm.py
@@ -51,6 +51,12 @@ def sort_gmm(gmm: GaussianMixture) -> tuple:
     return means, stds, weights, order
 
 
+def _weighted_pdf_gap(x: float, w0: float, m0: float, s0: float,
+                      w1: float, m1: float, s1: float) -> float:
+    """Difference of two weighted Gaussian PDFs — zero at their crossing point."""
+    return w0 * scipy_norm.pdf(x, m0, s0) - w1 * scipy_norm.pdf(x, m1, s1)
+
+
 def get_boundaries(means: np.ndarray, stds: np.ndarray, weights: np.ndarray) -> list:
     """
     Find the x-value where adjacent sorted components have equal weighted PDF.
@@ -58,12 +64,10 @@ def get_boundaries(means: np.ndarray, stds: np.ndarray, weights: np.ndarray) -> 
     """
     boundaries = []
     for i in range(len(means) - 1):
+        params = (weights[i],   means[i],   stds[i],
+                  weights[i+1], means[i+1], stds[i+1])
         try:
-            b = brentq(
-                lambda x: (weights[i]   * scipy_norm.pdf(x, means[i],   stds[i]) -
-                           weights[i+1] * scipy_norm.pdf(x, means[i+1], stds[i+1])),
-                means[i], means[i+1],
-            )
+            b = brentq(_weighted_pdf_gap, means[i], means[i+1], args=params)
         except ValueError:
             b = (means[i] + means[i+1]) / 2
         boundaries.append(b)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ target-version = "py311"
 # E,W = pycodestyle errors/warnings
 # I  = import sorting
 # C90 = mccabe complexity (the guard against function bloat)
-select = ["F", "E", "W", "I", "C90"]
+# B  = flake8-bugbear (likely bugs: B023 closure capture, B006/B008 mutable
+#      defaults, B905 zip without strict=)
+# NPY = NumPy-specific deprecations/removals (np.float_, np.bool, np.in1d, …)
+select = ["F", "E", "W", "I", "C90", "B", "NPY"]
 
 [tool.ruff.lint.isort]
 # The web package must import before the project-root analysis modules so
@@ -22,6 +25,12 @@ known-local-folder = [
     "analysis", "gmm", "parsing", "thresholds",
     "unit_conversions", "column_map", "stub_data",
 ]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection defaults (Depends/Query/File) are the
+# framework's intended "call in the default" idiom, not the B008 mutable-default
+# trap. Treat them as immutable so B008 doesn't fight the framework.
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.File"]
 
 [tool.ruff.lint.mccabe]
 # Ratchet: the current worst function scores 7. Cap at 10 so existing code

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -39,7 +39,7 @@ def test_each_result_has_required_keys(stub_df):
 
 def test_labels_cover_all_values(stub_df):
     results = analyse_upload(stub_df)
-    for name, res in results.items():
+    for _name, res in results.items():
         if "error" in res:
             continue
         assert len(res["labels"]) == len(res["values"])
@@ -226,7 +226,7 @@ def test_most_separated_marker_returns_marker_with_clearest_split(stub_df):
     assert name in results
     assert score > 0
     # All other multi-cluster markers should have score <= the picked one
-    for n, r in results.items():
+    for _n, r in results.items():
         if "error" in r or r.get("n_components", 0) < 2:
             continue
         pooled = float(np.mean(r["stds"]))

--- a/web/charts.py
+++ b/web/charts.py
@@ -81,7 +81,7 @@ def _marker_chart_html(data: dict, marker: str) -> str:
             name="Test values",
         ))
 
-    for i, (m, s, w) in enumerate(zip(means_d, stds_d, weights)):
+    for i, (m, s, w) in enumerate(zip(means_d, stds_d, weights, strict=True)):
         colour = CLUSTER_COLOURS[i % len(CLUSTER_COLOURS)]
         fig.add_trace(go.Scatter(
             x=x, y=w * scipy_norm.pdf(x, m, s),
@@ -89,7 +89,8 @@ def _marker_chart_html(data: dict, marker: str) -> str:
             name=f"Group {i + 1} · avg {m:.2f}",
         ))
 
-    total = sum(w * scipy_norm.pdf(x, m, s) for m, s, w in zip(means_d, stds_d, weights))
+    total = sum(w * scipy_norm.pdf(x, m, s)
+                for m, s, w in zip(means_d, stds_d, weights, strict=True))
     fig.add_trace(go.Scatter(
         x=x, y=total,
         mode="lines", line=dict(color="#1f1f1f", width=1, dash="dash"),
@@ -165,7 +166,7 @@ def _population_scatter_html(data: dict, colour_by: str = "type") -> str:
                 x=X2[mask, 0], y=X2[mask, 1], mode="markers",
                 marker=dict(size=11, color=CLUSTER_COLOURS[g % len(CLUSTER_COLOURS)]),
                 name=f"Cluster {g + 1}",
-                text=[pid for pid, m in zip(patient_ids, mask) if m],
+                text=[pid for pid, m in zip(patient_ids, mask, strict=True) if m],
                 hovertemplate="<b>%{text}</b><extra></extra>",
             ))
 
@@ -210,7 +211,7 @@ def _pair_chart_html(data: dict, x_marker: str, y_marker: str, colour_by: str = 
 
     pop = data["pop_results"]
     pop_label_lookup = (
-        dict(zip(pop["patient_ids"], pop["labels"]))
+        dict(zip(pop["patient_ids"], pop["labels"], strict=True))
         if "labels" in pop else {}
     )
 
@@ -225,7 +226,7 @@ def _pair_chart_html(data: dict, x_marker: str, y_marker: str, colour_by: str = 
                 x=xs[mask], y=ys[mask], mode="markers",
                 marker=dict(size=10, color=CLUSTER_COLOURS[g % len(CLUSTER_COLOURS)]),
                 name=f"Cluster {g + 1}",
-                text=[pid for pid, m in zip(wide.index, mask) if m],
+                text=[pid for pid, m in zip(wide.index, mask, strict=True) if m],
                 hovertemplate=(
                     f"<b>%{{text}}</b><br>{x_marker}: %{{x:.2f}} {disp_x}"
                     f"<br>{y_marker}: %{{y:.2f}} {disp_y}<extra></extra>"

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -129,7 +129,7 @@ def _population_context(data: dict, colour_by: str = "type") -> dict:
             if len(bullets) >= 5:
                 break
 
-        members = [pid for pid, lbl in zip(patient_ids, labels) if lbl == g]
+        members = [pid for pid, lbl in zip(patient_ids, labels, strict=True) if lbl == g]
         ages_g = [
             age_lookup.get(pid) for pid in members
             if age_lookup.get(pid) is not None and pd.notna(age_lookup.get(pid))


### PR DESCRIPTION
## Why
The initial ruff config (#35) selects `F, E, W, I, C90`. `B` (flake8-bugbear) and `NPY` (NumPy-specific) are two low-false-positive rule sets that catch a class of *real bugs* the current set misses — closure capture, mutable defaults, `zip` truncation, and NumPy 2.x deprecations.

## What changed
Added `B`, `NPY` to `select` in `pyproject.toml` and fixed every finding (no blanket ignores):

| Rule | Count | Fix |
|------|-------|-----|
| **B905** `zip()` without `strict=` | 6 | `strict=True` on all — each pair is equal-length by construction (incl. the `zip(patient_ids, labels)` in `web/contexts.py` the issue flagged). Now raises instead of silently truncating if lengths diverge. |
| **B023** loop var captured in closure | 6 | The `brentq` lambda in `gmm.py` closed over `i`; refactored to a module-level `_weighted_pdf_gap` receiving per-iteration values via `brentq`'s `args=`. Closure gone. |
| **B007** unused loop control var | 2 | Two test loops renamed to `_name` / `_n`. |
| **B008** call in arg default | 13 | All FastAPI `Depends`/`Query`/`File` DI defaults — marked immutable via `flake8-bugbear.extend-immutable-calls` (documented exception, the standard FastAPI+ruff approach). |
| **NPY** | 0 | Nothing surfaced — cheap insurance going forward. |

Per the issue, **`PD` (pandas-vet) was deliberately not added** (noisy here).

## Verification
- `ruff check .` clean.
- Full suite green: **236 passed**.
- The `gmm.py` refactor is numerically identical — `demo_cache.pkl` regenerated to byte-identical output, so no cache change.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)