### PR TITLE
Harden test_index_each_tab_renders to a structural dispatch signal

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -56,18 +56,16 @@ def test_healthz_returns_ok() -> None:
 
 @pytest.mark.parametrize("tab", ["explorer", "population", "investigate", "pairs"])
 def test_index_each_tab_renders(tab: str) -> None:
+    """Full page renders end-to-end and dispatches to the requested tab.
+
+    A 200 proves the shell + tab partial rendered without a template error.
+    The tab strip marks exactly the requested tab `is-active` (driven by the
+    same `active` var that selects the body partial), so it's the structural
+    signal of correct dispatch — no need to pin tab-specific copy.
+    """
     res = client.get(f"/?tab={tab}")
     assert res.status_code == 200
-    assert f'data-mdr-section="{tab}"' in res.text
-    # The methodology drawer lists all four sections on every page, so it can't
-    # tell tabs apart — assert a body element unique to each tab's partial.
-    body_markers = {
-        "explorer":    'id="marker-picker"',
-        "population":  "What defines each cluster",
-        "investigate": "finding-empty",  # demo cohort flags nothing
-        "pairs":       ">X axis<",
-    }
-    assert body_markers[tab] in res.text
+    assert re.search(rf'class="tab is-active"\s+href="/\?tab={tab}', res.text)
 
 
 def test_index_default_tab_is_explorer() -> None:


### PR DESCRIPTION
## Why
Follow-up to the tab-chrome cleanup (#45). `test_index_each_tab_renders` told tabs apart by pinning body **copy** — first the intro paragraphs, then markup like "What defines each cluster" / `finding-empty`. That's the wrong thing to assert: the copy exists for humans, it broke when the intros were removed, and the `finding-empty` marker silently depended on the demo cohort flagging nothing.

## What changed
Assert the **tab strip's `is-active` class** instead — exactly one tab carries it, and it's driven by the same `active` variable that selects the body partial, so it's the structural signal of correct dispatch:

```python
res = client.get(f"/?tab={tab}")
assert res.status_code == 200          # shell + tab partial rendered, no template error
assert re.search(rf'class="tab is-active"\s+href="/\?tab={tab}', res.text)
```

The 200 already covers "rendered end-to-end without throwing"; the regex covers "dispatched to the *right* tab". No dependency on flavour text or demo specifics.

Note: `data-mdr-section` and the per-tab `hx-get` were both rejected as signals — the methodology drawer and the tab strip each list all four on every page, so neither discriminates. `is-active` is the only per-tab-unique structural marker (verified: exactly one per page, always on the requested tab).

## Verification
- `ruff check` clean.
- Full suite green: **236 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)