### PR TITLE
Reveal a new marker's range editor without a refit

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -109,7 +109,7 @@ def test_outliers_tab_has_no_per_view_control() -> None:
 
 
 def test_cohort_popover_closed_by_default_open_while_editing() -> None:
-    open_re = r'<details class="cohort[^"]*" open>'
+    open_re = r'id="cohort"[^>]* open>'
     plain = client.get("/?tab=explorer").text
     assert not re.search(open_re, plain)             # collapsed on a normal load
     # Editing a filter re-renders the popover expanded so it stays open.
@@ -247,6 +247,38 @@ def test_filters_add_marker_shows_in_bar(demo_marker: str) -> None:
     assert res.status_code == 200
     # The added marker appears as an editable pill in the filter bar.
     assert _is_filtered(res.text)
+    assert demo_marker in res.text
+
+
+def test_add_marker_is_fast_path_no_refit(demo_marker: str) -> None:
+    """Adding a marker returns only the cohort popover — no chart, and the
+    full-range filter leaves the cohort count unchanged. It must not refit."""
+    res = client.get(f"/filters/add?tab=explorer&marker={demo_marker}")
+    assert res.status_code == 200
+    # Only the popover fragment: an editable pill, but no chart and no shell.
+    assert 'id="cohort"' in res.text
+    assert "plotly-graph-div" not in res.text
+    assert "tab-strip" not in res.text
+    # Full-range add changes nothing: cohort still the whole dataset.
+    n_full = state.df_long_full["patient_id"].nunique()
+    assert _cohort_active_count(res.text) == n_full
+    # The new pill's lower bound is autofocused for immediate editing.
+    assert "autofocus" in res.text
+
+
+def test_add_marker_does_not_call_gmm(monkeypatch, demo_marker: str) -> None:
+    """Hard proof the add fast-path skips the GMM refit: make the fit explode
+    and confirm the add still succeeds."""
+    import web.state as st
+
+    def _boom(*_a, **_k):
+        raise AssertionError("unexpected GMM refit on add")
+
+    monkeypatch.setattr(st, "analyse_population", _boom)
+    monkeypatch.setattr(st, "analyse_upload", _boom)
+    st._filtered_data_cached.cache_clear()  # avoid a cache hit masking a refit
+    res = client.get(f"/filters/add?tab=explorer&marker={demo_marker}")
+    assert res.status_code == 200
     assert demo_marker in res.text
 
 

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -21,6 +21,7 @@ from web.charts import (
 )
 from web.filters import FilterSpec
 from web.state import (
+    _cohort_count,
     _display_unit,
     _filter_ui_context,
     _units_ui_context,
@@ -307,6 +308,20 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
 
 
 # ── Cross-tab context (left rail + page chrome) ──────────────────────────────
+
+def _cohort_context(spec: FilterSpec) -> dict:
+    """Context for the cohort popover alone — the chips, count, and add control,
+    WITHOUT a GMM refit. Used by the fast-path add route so revealing a new
+    marker's range editor is instant (a full-range filter changes nothing)."""
+    return {
+        "filters":    spec,
+        "filter_qs":  spec.to_query_string(),
+        "filtered":   spec.is_active(),
+        "n_full":     state.df_long_full["patient_id"].nunique(),
+        "n_active":   _cohort_count(spec),
+        **_filter_ui_context(spec),
+    }
+
 
 def _common(spec: FilterSpec, data: dict) -> dict:
     n_full = state.df_long_full["patient_id"].nunique()

--- a/web/main.py
+++ b/web/main.py
@@ -18,6 +18,7 @@ from fastapi.templating import Jinja2Templates
 # putting PROJECT_ROOT on sys.path before any project-root module is touched.
 from web.contexts import (
     _build_tab_ctx,
+    _cohort_context,
     _common,
     _marker_context,
     _pair_context,
@@ -178,14 +179,29 @@ def add_filter_partial(
     age_max: int | None = None,
     m: list[str] = Query(default_factory=list),
 ) -> HTMLResponse:
+    """Reveal a new marker's range editor — fast-path, no GMM refit.
+
+    The marker is added at its FULL range, which filters out nothing, so the
+    results don't change. We therefore re-render only the cohort popover (with
+    the new editable pill, focused) and leave the chart untouched. The refit
+    happens later, when the user actually narrows the range via /set-marker.
+    """
     age_min, age_max = _normalise_age(age_min, age_max)
     new_m = list(m)
+    added: str | None = None
     if marker and marker in state.df_long_full["test_name"].unique():
         rng = _marker_value_range(marker)
         if rng is not None:
             new_m.append(f"{marker}:{rng[0]}:{rng[1]}")
+            added = marker
     spec = FilterSpec.from_request(age_min, age_max, new_m)
-    return _filter_response(request, spec, tab, full=False, cohort_open=True)
+    ctx = {
+        "active": _resolve_tab(tab),
+        "cohort_open": True,
+        "focus_marker": added,
+        **_cohort_context(spec),
+    }
+    return templates.TemplateResponse(request, "partials/_cohort_popover.html", ctx)
 
 
 @app.get("/filters/set-marker", response_class=HTMLResponse)

--- a/web/state.py
+++ b/web/state.py
@@ -67,11 +67,9 @@ def _full_data() -> dict:
     }
 
 
-@functools.lru_cache(maxsize=32)
-def _filtered_data_cached(spec: FilterSpec) -> dict:
-    """Compute and cache the filtered analysis. Bounded LRU keeps memory in
-    check on the 512 MB Render free tier — each entry is ~400 KB. Callers
-    must NOT mutate the returned dict; cache hits return the same object."""
+def _spec_filtered_long(spec: FilterSpec):
+    """Apply a FilterSpec to the full long-frame — the cheap pandas filter, no
+    GMM refit. Used both by the cached analysis and by the cohort count."""
     age_range: tuple | None = None
     if spec.age_min is not None or spec.age_max is not None:
         full_range = _age_full_range()
@@ -80,8 +78,21 @@ def _filtered_data_cached(spec: FilterSpec) -> dict:
         age_range = (lo, hi)
 
     marker_ranges = {mf.marker: (mf.lo, mf.hi) for mf in spec.markers}
+    return filter_long(state.df_long_full, age_range=age_range, marker_ranges=marker_ranges)
 
-    df_filtered = filter_long(state.df_long_full, age_range=age_range, marker_ranges=marker_ranges)
+
+def _cohort_count(spec: FilterSpec) -> int:
+    """Number of blood tests matching `spec` — cheap (no GMM refit)."""
+    df = _spec_filtered_long(spec)
+    return df["patient_id"].nunique() if not df.empty else 0
+
+
+@functools.lru_cache(maxsize=32)
+def _filtered_data_cached(spec: FilterSpec) -> dict:
+    """Compute and cache the filtered analysis. Bounded LRU keeps memory in
+    check on the 512 MB Render free tier — each entry is ~400 KB. Callers
+    must NOT mutate the returned dict; cache hits return the same object."""
+    df_filtered = _spec_filtered_long(spec)
     n = df_filtered["patient_id"].nunique() if not df_filtered.empty else 0
 
     if n < 4:

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -32,5 +32,17 @@
       {% block main %}{% endblock %}
     </main>
   </div>
+
+  <script>
+    // HTMX drops native autofocus on swapped-in content, so restore it: after
+    // any swap, focus the [autofocus] input (only the fast-path "add marker"
+    // fragment sets one) and select its value for immediate editing.
+    document.body.addEventListener("htmx:afterSwap", function (e) {
+      var scope = e.target;
+      if (!scope || !scope.querySelector) return;
+      var el = scope.querySelector("input[autofocus]");
+      if (el) { el.focus(); if (el.select) el.select(); }
+    });
+  </script>
 </body>
 </html>

--- a/web/templates/partials/_cohort_popover.html
+++ b/web/templates/partials/_cohort_popover.html
@@ -2,7 +2,7 @@
    popover holds age + per-marker ranges + add + reset. No JS: native
    disclosure. Filter routes pass `cohort_open` so the popover stays open
    while the user is editing (each mutation re-renders this fragment). #}
-<details class="cohort{% if filtered %} is-filtered{% endif %}"{% if cohort_open %} open{% endif %}>
+<details class="cohort{% if filtered %} is-filtered{% endif %}" id="cohort"{% if cohort_open %} open{% endif %}>
   <summary class="cohort-summary">
     <span class="cohort-summary-label">Cohort</span>
     <span class="cohort-summary-count">{{ n_active }} of {{ n_full }} tests</span>
@@ -57,7 +57,8 @@
         <span class="cohort-row-label">{{ chip.marker }}</span>
         <input class="cohort-num" type="number" name="lo" step="any"
                min="{{ chip.full_lo }}" max="{{ chip.full_hi }}"
-               value="{{ "%g"|format(chip.lo) }}" />
+               value="{{ "%g"|format(chip.lo) }}"
+               {% if focus_marker is defined and focus_marker == chip.marker %}autofocus{% endif %} />
         <span class="filter-range-sep">–</span>
         <input class="cohort-num" type="number" name="hi" step="any"
                min="{{ chip.full_lo }}" max="{{ chip.full_hi }}"
@@ -77,8 +78,8 @@
         class="cohort-row"
         hx-get="/filters/add"
         hx-trigger="change"
-        hx-target="#page-body"
-        hx-swap="innerHTML"
+        hx-target="#cohort"
+        hx-swap="outerHTML"
         autocomplete="off"
       >
         <input type="hidden" name="tab" value="{{ active }}" />


### PR DESCRIPTION
Part of the **Cohort filter UX** milestone (#4). Builds on the toolbar from #51.

## Why
Selecting a marker added it at its **full range** — a no-op filter — yet still refit every GMM (~1s locally, several seconds on Render) before revealing the range editor. Action → long wait → no visible change = "feels broken."

## What
`/filters/add` is now a **fast path**: it returns *only* the cohort popover fragment (no `_filtered_data`, no page-body swap), with the new marker's editable pill pre-filled to its full range and the `lo` input **autofocused**. The chart is left untouched — a full-range filter changes nothing, so the displayed results stay correct. The refit happens later, when the user actually narrows the range via `/set-marker`.

- The add control targets `#cohort` (outerHTML) instead of `#page-body`.
- `web/state.py`: factored the cheap pandas filter into `_spec_filtered_long` + `_cohort_count` (reused by the cached analysis, so no duplicated spec→args logic); `web/contexts.py` adds `_cohort_context` (popover context with no GMM refit).
- `base.html`: a 4-line `htmx:afterSwap` shim restores `autofocus` (HTMX drops it on swapped content) and selects the value for immediate typing.

## Result (measured)
| Action | Before | After |
|---|---|---|
| Add a marker | ~1.0s | **~0.02s** (≈ a plain render) |
| Narrow a range (`set-marker`) | ~1.3s | ~1.3s (still refits — correct) |

## Tests
- `add` returns popover-only (no `plotly-graph-div`, no `tab-strip`), cohort count unchanged, `lo` autofocused.
- A monkeypatched test makes `analyse_population`/`analyse_upload` explode and confirms add still succeeds — hard proof it skips the GMM.
- `ruff check .` clean; full suite **241 passed**.

## Note
Transient: between adding a marker and editing its range, the marker picker's links still carry the pre-add filter string. Since the added filter is a no-op until edited, this is harmless — and editing the range refreshes the whole page with the correct state.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)