### PR TITLE
Add a loading indicator for filter recomputes

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -108,6 +108,16 @@ def test_outliers_tab_has_no_per_view_control() -> None:
     assert "cohort-summary" in html
 
 
+def test_refit_indicator_wired_to_results() -> None:
+    """The results carry an hx-indicator + overlay so cohort recomputes dim
+    the chart and show 'Updating…'. Controls inside #page-body inherit it."""
+    html = client.get("/").text
+    assert 'id="results-wrap"' in html
+    assert 'hx-indicator="#results-wrap"' in html
+    assert 'class="refit-overlay"' in html
+    assert "Updating" in html
+
+
 def test_cohort_popover_closed_by_default_open_while_editing() -> None:
     open_re = r'id="cohort"[^>]* open>'
     plain = client.get("/?tab=explorer").text

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -604,6 +604,59 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
 
 .filter-range-sep { color: var(--ink-3); font-size: 0.85rem; }
 
+/* ── Refit loading indicator ───────────────────────────────────────────── */
+
+#results-wrap { position: relative; }
+
+#tab-body { transition: opacity 150ms ease; }
+
+/* HTMX adds .htmx-request to the indicator target (#results-wrap) while a
+   recompute is in flight. Dim only #tab-body so the toolbar/cohort controls
+   stay crisp and interactive. The 120ms show-delay means fast swaps (the
+   instant add, cache hits) finish before anything appears — no flash. */
+#results-wrap.htmx-request #tab-body {
+  opacity: 0.4;
+  pointer-events: none;
+  transition-delay: 120ms;
+}
+
+.refit-overlay {
+  position: absolute;
+  top: 8.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.10);
+  font-size: 0.85rem;
+  color: var(--ink-2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease;
+}
+
+#results-wrap.htmx-request .refit-overlay {
+  opacity: 1;
+  transition-delay: 120ms;
+}
+
+.refit-spinner {
+  width: 0.9rem;
+  height: 0.9rem;
+  border: 2px solid var(--accent-100);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: refit-spin 0.6s linear infinite;
+}
+
+@keyframes refit-spin { to { transform: rotate(360deg); } }
+
 /* ── Data-section reset link (left rail) ───────────────────────────────── */
 
 .filter-reset {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -21,8 +21,17 @@
     </div>
   {% endif %}
 
-  <div id="page-body">
-    {% include "partials/page_body.html" %}
+  {# Refit indicator: hx-indicator is inherited by every control inside
+     #page-body, so any request that recomputes the cohort dims the results
+     and shows the overlay. The instant "add marker" (~20ms) never flashes —
+     the CSS show-delay outlasts it. #}
+  <div id="results-wrap">
+    <div class="refit-overlay" aria-hidden="true">
+      <span class="refit-spinner"></span>Updating…
+    </div>
+    <div id="page-body" hx-indicator="#results-wrap">
+      {% include "partials/page_body.html" %}
+    </div>
   </div>
 
   {% include "partials/_methodology_drawer.html" %}


### PR DESCRIPTION
Final PR of the **Cohort filter UX** milestone (#4).

## Why
The legitimate refits (narrowing a range, removing a filter, switching marker / X–Y) take ~1s and read as a freeze. Close the action→feedback loop with a visible "Updating…" affordance.

## What
- Wrap `#page-body` in `#results-wrap` with an **"Updating…" overlay** (spinner + label) and put `hx-indicator="#results-wrap"` on `#page-body`. HTMX **inherits** `hx-indicator`, so every recompute control inside picks it up automatically — no per-control wiring.
- While a request is in flight, **only `#tab-body` (the results) dims** to 0.4 and the overlay fades in; the **toolbar + cohort controls stay crisp and interactive** so you can keep adjusting.
- A **120ms show-delay** means fast swaps never flash — the instant "add marker" (~20ms) and LRU cache hits finish before the dim begins. No special-casing for add.
- CSS-only via HTMX's `htmx-request` class; the only JS is the focus shim from #52.

## Verification
- Forced-on screenshots confirm: chart dims under the centered "⟳ Updating…" pill; toolbar/cohort untouched.
- `ruff check .` clean; full suite **242 passed** (1 new test for the indicator markup).

## Scope note
Covers recomputes triggered from `#page-body` (the four filter routes + the per-view marker/X–Y/colour-by controls — all genuine refits). The rail's display-units control is outside `#page-body` and out of scope here.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)