### PR TITLE
Fix filter/tab URL bookmarkability + polish the cohort popover

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -446,6 +446,27 @@ def test_full_parameterised_url_restores_cohort_tab_and_drawer(
     assert _is_filtered(res.text)
 
 
+def test_filter_mutation_pushes_canonical_url(demo_marker: str) -> None:
+    """Filter mutations must push the bookmarkable /?… page URL — not the bare
+    /filters/* endpoint, which renders shell-less (no CSS) on reload."""
+    res = client.get(f"/filters/set?tab=pairs&age_min=35&age_max=55&m={demo_marker}:0:9999")
+    pushed = res.headers.get("HX-Push-Url")
+    assert pushed is not None and pushed.startswith("/?tab=pairs")
+    assert "age_min=35" in pushed and f"m={demo_marker}" in pushed
+    assert "/filters/" not in pushed
+    # And that pushed URL must actually serve the full styled shell.
+    full = client.get(pushed)
+    assert "/static/styles.css" in full.text and "<html" in full.text
+
+
+def test_tab_switch_pushes_canonical_url() -> None:
+    """Switching tabs must push /?tab=… (full page), not the /tab/* fragment."""
+    res = client.get("/tab/population")
+    pushed = res.headers.get("HX-Push-Url")
+    assert pushed == "/?tab=population"
+    assert "/static/styles.css" in client.get(pushed).text
+
+
 # ── Upload ───────────────────────────────────────────────────────────────────
 
 def _csv_bytes(rows: list[dict[str, str]]) -> bytes:

--- a/web/main.py
+++ b/web/main.py
@@ -82,7 +82,18 @@ def _filter_response(
     `cohort_open` re-renders the cohort popover expanded, so it stays open
     while the user edits a range."""
     template = "partials/full_render.html" if full else "partials/page_body.html"
-    return _page_response(request, spec, tab, template, {"cohort_open": cohort_open})
+    resp = _page_response(request, spec, tab, template, {"cohort_open": cohort_open})
+    # Push the canonical full-page URL (not this /filters/* endpoint), so a
+    # reload / bookmark / share lands on the styled page, with the cohort
+    # preserved in query params.
+    resp.headers["HX-Push-Url"] = _canonical_url(_resolve_tab(tab), spec)
+    return resp
+
+
+def _canonical_url(tab: str, spec: FilterSpec) -> str:
+    """The bookmarkable address-bar URL for a tab + cohort: `/?tab=…&m=…`."""
+    qs = spec.to_query_string()
+    return f"/?tab={tab}" + (f"&{qs}" if qs else "")
 
 
 # ── Page + tab routes ────────────────────────────────────────────────────────
@@ -107,7 +118,11 @@ def tab_partial(
     name: str,
     spec: FilterSpec = Depends(get_filter_spec),
 ) -> HTMLResponse:
-    return _page_response(request, spec, name, "partials/page_body.html")
+    resp = _page_response(request, spec, name, "partials/page_body.html")
+    # Push the canonical full-page URL so a reload of a switched tab lands on
+    # the styled page, not this bare /tab/* fragment.
+    resp.headers["HX-Push-Url"] = _canonical_url(_resolve_tab(name), spec)
+    return resp
 
 
 @app.get("/marker", response_class=HTMLResponse)

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -514,15 +514,23 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
   right: 0;
   top: calc(100% + 0.45rem);
   z-index: 50;
-  min-width: 17rem;
-  padding: 0.85rem;
+  width: 19rem;
+  padding: 0.9rem;
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
+  gap: 0.5rem;
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.10);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.cohort-popover-head {
+  font-size: 0.76rem;
+  color: var(--ink-3);
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.1rem;
+  border-bottom: 1px solid var(--line);
 }
 
 .cohort-row {
@@ -533,18 +541,21 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
 }
 
 .cohort-row-label {
-  min-width: 4.5rem;
+  flex: 0 0 5.5rem;            /* fixed column so every row's inputs line up */
   font-size: 0.83rem;
   font-weight: 600;
   color: var(--ink-2);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;    /* long marker names truncate (full name on hover) */
 }
 
 .cohort-num {
   font-family: inherit;
   font-size: 0.83rem;
-  width: 3.4rem;
-  padding: 0.25rem 0.35rem;
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0.3rem 0.4rem;
   background: var(--bg);
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -558,15 +569,22 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
   box-shadow: 0 0 0 3px var(--accent-50);
 }
 
-.cohort-unit { font-size: 0.78rem; color: var(--ink-3); }
+.cohort-trailing {
+  flex: 0 0 3.5rem;           /* fixed trailing column keeps the × aligned */
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+}
+
+.cohort-unit { font-size: 0.78rem; color: var(--ink-3); white-space: nowrap; }
 
 .cohort-remove {
-  margin-left: auto;
   font-size: 1rem;
   line-height: 1;
   color: var(--ink-3);
   cursor: pointer;
-  padding: 0.1rem 0.4rem;
+  padding: 0.1rem 0.35rem;
   border-radius: 4px;
   text-decoration: none;
   transition: background 120ms ease, color 120ms ease;
@@ -578,7 +596,8 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
   font-family: inherit;
   font-size: 0.83rem;
   width: 100%;
-  padding: 0.4rem 0.5rem;
+  margin-top: 0.15rem;
+  padding: 0.45rem 0.5rem;
   background: var(--bg);
   border: 1px dashed var(--line);
   border-radius: 6px;
@@ -590,7 +609,11 @@ details.rail-disclosure[open] summary::after { transform: rotate(90deg); }
 .cohort-add:hover { border-color: var(--accent); color: var(--ink); }
 .cohort-add:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
 
-.cohort-foot { margin-top: 0.1rem; }
+.cohort-foot {
+  margin-top: 0.3rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--line);
+}
 
 .cohort-reset {
   font-size: 0.82rem;

--- a/web/templates/partials/_cohort_popover.html
+++ b/web/templates/partials/_cohort_popover.html
@@ -10,6 +10,7 @@
   </summary>
 
   <div class="cohort-popover">
+    <div class="cohort-popover-head">Restrict the analysis to a subset of blood tests.</div>
     {% if age_full %}
       <form
         class="cohort-row"
@@ -32,6 +33,7 @@
         <input class="cohort-num" type="number" name="age_max"
                min="{{ age_full[0] }}" max="{{ age_full[1] }}"
                value="{{ filters.age_max if filters.age_max is not none else age_full[1] }}" />
+        <span class="cohort-trailing"></span>
       </form>
     {% endif %}
 
@@ -54,7 +56,7 @@
             <input type="hidden" name="m" value="{{ other.marker }}:{{ other.lo }}:{{ other.hi }}" />
           {% endif %}
         {% endfor %}
-        <span class="cohort-row-label">{{ chip.marker }}</span>
+        <span class="cohort-row-label" title="{{ chip.marker }}">{{ chip.marker }}</span>
         <input class="cohort-num" type="number" name="lo" step="any"
                min="{{ chip.full_lo }}" max="{{ chip.full_hi }}"
                value="{{ "%g"|format(chip.lo) }}"
@@ -63,13 +65,15 @@
         <input class="cohort-num" type="number" name="hi" step="any"
                min="{{ chip.full_lo }}" max="{{ chip.full_hi }}"
                value="{{ "%g"|format(chip.hi) }}" />
-        {% if chip.unit %}<span class="cohort-unit">{{ chip.unit }}</span>{% endif %}
-        <a class="cohort-remove"
-           title="Remove {{ chip.marker }} filter"
-           hx-get="/filters/remove?marker={{ chip.marker | urlencode }}&tab={{ active }}{% if filter_qs %}&{{ filter_qs }}{% endif %}"
-           hx-target="#page-body"
-           hx-swap="innerHTML"
-           hx-push-url="true">×</a>
+        <span class="cohort-trailing">
+          {% if chip.unit %}<span class="cohort-unit">{{ chip.unit }}</span>{% endif %}
+          <a class="cohort-remove"
+             title="Remove {{ chip.marker }} filter"
+             hx-get="/filters/remove?marker={{ chip.marker | urlencode }}&tab={{ active }}{% if filter_qs %}&{{ filter_qs }}{% endif %}"
+             hx-target="#page-body"
+             hx-swap="innerHTML"
+             hx-push-url="true">×</a>
+        </span>
       </form>
     {% endfor %}
 


### PR DESCRIPTION
Follow-up to the Cohort filter UX milestone (#4), from review feedback.

## The bug behind the "unstyled page" screenshot
Filter and tab controls used `hx-push-url="true"`, which pushes the **`/filters/*` and `/tab/*` endpoint URLs** into the address bar. Those routes return **shell-less fragments** (no `<html>`, no `styles.css`). So after changing a filter or tab, a **reload / bookmark / share** fetched the bare fragment and rendered the page raw and unstyled — exactly the reported screenshot.

### Fix
Filter mutations and tab switches now push the **canonical full-page URL** (`/?tab=…&age_min=…&m=…`) via an `HX-Push-Url` response header (which overrides the template attribute). Reload/bookmark now lands on the styled page with the cohort preserved — restoring the bookmarkability CLAUDE.md promises.

```
GET /filters/set?…  → HX-Push-Url: /?tab=pairs&age_min=35&age_max=55&m=…
GET /tab/population  → HX-Push-Url: /?tab=population
```

## Polish (same custom design system — no new dependencies)
Re: "is this using Tailwind components / should it be?" — the app deliberately hand-rolls its chrome in `styles.css` (a custom design system); Tailwind here is utilities-only and ships no components. The popover follows that system; this tightens it:
- **Fixed-width, truncating label column** so every row's lo/hi inputs line up regardless of marker-name length (long names truncate, full name on hover).
- **Unit + remove (×) clustered in a fixed trailing column**, kept aligned across rows.
- A **header line** and a **separated reset footer** for clearer structure.

## Verification
- `ruff check .` clean; full suite **244 passed** (2 new tests asserting the pushed URL is canonical *and* serves the full styled shell).
- Screenshots confirm the polished popover columns align even with a long marker name truncated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)