### PR TITLE
Drop the unused Tailwind CDN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code when working in this repository.
 
 ## What this project is
 
-A FastAPI + HTMX + Tailwind app that discovers natural clusters in blood test results using unsupervised machine learning. Each row in the dataset is one **blood test** (a single panel result), not a patient-as-such. The app does **not** classify results as Normal/Borderline/Abnormal — it finds what groups exist.
+A FastAPI + HTMX app (with a hand-written CSS design system) that discovers natural clusters in blood test results using unsupervised machine learning. Each row in the dataset is one **blood test** (a single panel result), not a patient-as-such. The app does **not** classify results as Normal/Borderline/Abnormal — it finds what groups exist.
 
 Four tabs:
 - **1. Groups** — per-marker GMM, histogram + density curves, reference range lines.
@@ -119,7 +119,7 @@ If you change the return shape, update both `bake_demo.py` consumers and the tes
 
 ### Design system (`web/static/styles.css`)
 
-Typography scale: `t-eyebrow` (uppercase 0.72rem) / `t-h1` (2.0rem 600 weight) / `t-h2` / `t-body` / `t-meta`. One accent (`--accent: #4C72B0`); 5-step grayscale; cluster colours used only inside chart areas. Most chrome (cards, disclosures, control-bar, tab-strip) is custom CSS; Tailwind is loaded via CDN for utility classes only.
+Typography scale: `t-eyebrow` (uppercase 0.72rem) / `t-h1` (2.0rem 600 weight) / `t-h2` / `t-body` / `t-meta`. One accent (`--accent: #4C72B0`); 5-step grayscale; cluster colours used only inside chart areas. All chrome (cards, disclosures, toolbar, tab-strip, cohort popover) is custom CSS in `styles.css` — no CSS framework. There is no front-end build step; `styles.css` is served as-is.
 
 Each tab follows the same shape:
 1. **Intro card** (boxed) — what the view shows + named ML technique

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blood Test Classifier
 
-A FastAPI + HTMX + Tailwind app for discovering patterns in blood test results using unsupervised machine learning. Upload a wide-format CSV of blood test results and the app identifies natural clusters — without pre-labelling them — so you can interpret what those clusters mean.
+A FastAPI + HTMX app for discovering patterns in blood test results using unsupervised machine learning. Upload a wide-format CSV of blood test results and the app identifies natural clusters — without pre-labelling them — so you can interpret what those clusters mean.
 
 Each row in the dataset is treated as one **blood test** (a single panel of marker results), not a patient-as-such.
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -5,14 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Blood Test Classifier{% endblock %}</title>
 
-  <!-- Tailwind via CDN for the prototype. Production: compile locally. -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      corePlugins: { preflight: false },  // keep our own typography
-    };
-  </script>
-
   <!-- HTMX -->
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
 


### PR DESCRIPTION
## Why
An audit showed the app uses **~0 Tailwind utility classes** — all chrome is custom CSS in `styles.css` (~1.1k lines). The only Tailwind present was the **dev-only `cdn.tailwindcss.com` "play" build** with `preflight: false` (so not even a CSS reset). It:
- prints a "should not be used in production" console warning,
- adds a render-blocking script + in-browser JIT that scans the DOM,
- ships the whole framework (no purge) for no benefit.

So it was pure dead weight. (Chosen option #1 from the design-system discussion: commit to custom CSS, drop the vestigial dependency.)

## What changed
- Removed the `<script src="cdn.tailwindcss.com">` + `tailwind.config` block from `base.html`.
- Updated stale "FastAPI + HTMX + **Tailwind**" / "Tailwind loaded via CDN" wording in `README.md` and `CLAUDE.md` to reflect the hand-written CSS design system + no front-end build step.

## Verification
- Page renders **pixel-identically** without it (headless screenshot before/after).
- No `tailwind` reference remains in the served HTML.
- `ruff check .` clean; full suite **244 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)