### PR TITLE
Make CSV upload failures visible (and never silent)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -508,21 +508,24 @@ def test_upload_happy_path_replaces_demo_state() -> None:
     assert state.df_long_full["patient_id"].nunique() == 5
 
 
-def test_upload_too_few_rows_returns_400() -> None:
+# Upload errors return 200 (not 4xx) on purpose: HTMX does not swap the body
+# of an error response, so a 4xx would show the user nothing. The error is
+# rendered inline as a .cohort-error fragment instead.
+
+def test_upload_too_few_rows_shows_inline_error() -> None:
     csv = _valid_upload_csv(n_rows=2)
     res = client.post(
         "/upload",
         files={"file": ("small.csv", io.BytesIO(csv), "text/csv")},
     )
-    assert res.status_code == 400
-    assert "need at least 4" in res.text
-    # Demo state should still be intact.
-    assert state.is_demo is True
+    assert res.status_code == 200
+    assert "cohort-error" in res.text and "need at least 4" in res.text
+    assert state.is_demo is True  # demo state intact
 
 
-def test_upload_unrecognised_columns_returns_400() -> None:
+def test_upload_unrecognised_columns_shows_inline_error() -> None:
     """A CSV with no recognised column maps still has the ID column, parses
-    to an empty long-frame, and is rejected with a clear message."""
+    to an empty long-frame, and is rejected with a clear visible message."""
     csv = textwrap.dedent("""\
         Blood Test Info Blood Test ID,Wholly Unknown Column,Another Random One
         P001,1,2
@@ -535,22 +538,39 @@ def test_upload_unrecognised_columns_returns_400() -> None:
         "/upload",
         files={"file": ("unknown.csv", io.BytesIO(csv), "text/csv")},
     )
-    assert res.status_code == 400
-    assert "No recognised columns" in res.text
+    assert res.status_code == 200
+    assert "cohort-error" in res.text and "No recognised columns" in res.text
     assert state.is_demo is True
 
 
-def test_upload_unparseable_input_returns_400() -> None:
+def test_upload_unparseable_input_shows_inline_error() -> None:
     """Bytes that pandas can't read as CSV produce the parse-error branch."""
-    # parse_csv expects the ID column; omitting it makes the row-filter raise.
     bad = b"not,a,valid\ncsv,without,id\n"
     res = client.post(
         "/upload",
         files={"file": ("garbage.csv", io.BytesIO(bad), "text/csv")},
     )
-    assert res.status_code == 400
-    assert "Could not read CSV" in res.text
+    assert res.status_code == 200
+    assert "cohort-error" in res.text and "Could not read CSV" in res.text
     assert state.is_demo is True
+
+
+def test_upload_analysis_failure_shows_inline_error(monkeypatch) -> None:
+    """If the analysis raises on an otherwise-valid CSV, the user gets a
+    visible error — not a silent 500 that HTMX drops."""
+    import web.main as wm
+
+    def _boom(*_a, **_k):
+        raise ValueError("degenerate marker")
+
+    monkeypatch.setattr(wm, "analyse_upload", _boom)
+    res = client.post(
+        "/upload",
+        files={"file": ("ok.csv", io.BytesIO(_valid_upload_csv(n_rows=5)), "text/csv")},
+    )
+    assert res.status_code == 200
+    assert "cohort-error" in res.text and "Could not analyse" in res.text
+    assert state.is_demo is True  # failed upload must not wipe the demo
 
 
 def test_upload_reset_restores_demo() -> None:

--- a/web/main.py
+++ b/web/main.py
@@ -13,6 +13,7 @@ from fastapi import Depends, FastAPI, File, Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from markupsafe import escape
 
 # web.* imports first so web/__init__.py is unambiguously responsible for
 # putting PROJECT_ROOT on sys.path before any project-root module is touched.
@@ -263,43 +264,50 @@ def reset_filters_partial(request: Request, tab: str = "explorer") -> HTMLRespon
 
 # ── Upload ───────────────────────────────────────────────────────────────────
 
+def _upload_error(msg: str) -> Response:
+    """Inline upload-error fragment. Returned with status 200 on purpose:
+    HTMX does not swap the body of a 4xx/5xx response, so an error code would
+    show the user nothing. The message goes into #upload-result instead."""
+    state.last_upload_error = msg
+    return Response(
+        content=f'<div class="cohort-error">{escape(msg)}</div>',
+        status_code=200, media_type="text/html",
+    )
+
+
 @app.post("/upload")
 async def upload_csv(file: UploadFile = File(...)) -> Response:
     """Parse the uploaded CSV, run the full analysis, and replace the demo state.
 
-    Returns an HX-Redirect so HTMX reloads the page (clears all in-page state
-    cleanly). On parse failure, returns an HTML fragment for inline display.
+    On success returns an HX-Redirect so HTMX reloads the page cleanly. Every
+    failure mode returns a visible inline error (status 200) — never a silent
+    4xx/5xx that HTMX would drop.
     """
     contents = await file.read()
     try:
         df_long, _recognised, _unrecognised = parse_csv(io.BytesIO(contents))
     except Exception as exc:  # noqa: BLE001
-        state.last_upload_error = f"Could not read CSV: {exc}"
-        return Response(
-            content=f'<div class="cohort-error">Could not read CSV: {exc}</div>',
-            status_code=400, media_type="text/html",
-        )
+        return _upload_error(f"Could not read CSV: {exc}")
 
     if df_long.empty:
-        state.last_upload_error = "No recognised columns in the upload."
-        return Response(
-            content='<div class="cohort-error">No recognised columns in the upload.</div>',
-            status_code=400, media_type="text/html",
+        return _upload_error(
+            "No recognised columns in the upload. Check the column headers match "
+            "the known marker names."
         )
 
     n_patients = df_long["patient_id"].nunique()
     if n_patients < 4:
-        state.last_upload_error = (
-            f"Only {n_patients} blood tests in the upload — need at least 4 to run analysis."
-        )
-        return Response(
-            content=f'<div class="cohort-error">{state.last_upload_error}</div>',
-            status_code=400, media_type="text/html",
+        return _upload_error(
+            f"Only {n_patients} blood test{'s' if n_patients != 1 else ''} in the "
+            "upload — need at least 4 to run analysis."
         )
 
-    gmm = analyse_upload(df_long)
-    pop = analyse_population(df_long)
-    df_labelled = build_labelled_df(df_long, gmm)
+    try:
+        gmm = analyse_upload(df_long)
+        pop = analyse_population(df_long)
+        df_labelled = build_labelled_df(df_long, gmm)
+    except Exception as exc:  # noqa: BLE001
+        return _upload_error(f"Could not analyse the upload: {exc}")
 
     state.df_long_full     = df_long
     state.gmm_results_full = gmm

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -407,6 +407,15 @@ details.disclosure > *:not(summary) { margin-top: 0.75rem; }
 
 .upload-button:hover { background: #2c2c2c; }
 
+.upload-status {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--ink-3);
+}
+
+/* While the upload is analysing, dim the button so the wait reads as busy. */
+form.htmx-request .upload-button { opacity: 0.5; pointer-events: none; }
+
 /* ── Rail disclosure (Display units etc.) ──────────────────────────────── */
 
 details.rail-disclosure summary {

--- a/web/templates/partials/_data_section.html
+++ b/web/templates/partials/_data_section.html
@@ -19,6 +19,7 @@
         onchange="this.form.requestSubmit()"
         style="display: none;"
       />
+      <span class="upload-status htmx-indicator">Analysing…</span>
     </form>
     <div id="upload-result"></div>
   {% else %}


### PR DESCRIPTION
## The bug
Uploading a CSV that failed validation or analysis appeared to **"do nothing."** I reproduced the happy path in a headless browser (it works — redirects and loads the data), which isolated it to the **error paths**. Two compounding causes:

1. **HTMX drops error-status bodies.** Every upload error returned **status 400**, but HTMX (by default) does **not** swap the body of a 4xx/5xx response — it just fires `htmx:responseError`. So every validation error (too few rows, unrecognized columns, parse failure) was silently discarded.
2. **The analysis wasn't wrapped.** `analyse_upload` / `analyse_population` / `build_labelled_df` ran outside the `try/except`, so a CSV that parsed but broke the GMM threw an unhandled **500** — also silently dropped.

So any non-happy upload showed the user nothing.

## The fix
- **Error fragments now return 200** so HTMX renders them inline in `#upload-result` (the meaning is in the message; the inline-error pattern doesn't need a 4xx).
- **The analysis is wrapped** in `try/except` and surfaced as a clear `Could not analyse the upload: …` message — never a silent 500.
- Error text is **HTML-escaped** (it interpolates the filename / exception).
- Added an **"Analysing…" indicator** + dimmed button so the ~1s analysis isn't a silent wait.

## Verification
- Reproduced in a same-origin headless harness: an unrecognized-columns CSV now shows the amber error box ("No recognised columns…") where before it showed nothing.
- Happy path unchanged (`HX-Redirect` → `/`, verified loading the uploaded data in-browser).
- Tests: the three error cases now assert **200 + a visible `.cohort-error` fragment + demo state intact**, plus a new monkeypatched test for the analysis-failure path.
- `ruff check .` clean; full suite **245 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)