### PR TITLE
Require an evidence floor before reporting more than one group/cluster

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -92,11 +92,12 @@ def analyse_population(df_long: pd.DataFrame) -> dict:
     n_cluster_dims = max(2, min(n_for_80, max_components))
     X_cluster     = X_pca[:, :n_cluster_dims]
 
-    # Sample-size-aware K cap (~25 patients per cluster minimum). Caps are
-    # max(2, min(5, n // 25)) so n=80 demo can reach at most K=3, n=125+ can
-    # reach K=5. Always include K=1 in the search so we can apply a ΔBIC=6
-    # threshold against the no-cluster null hypothesis.
-    max_k_by_size = max(2, min(5, n_patients // 25))
+    # Sample-size-aware K cap (~25 patients per cluster minimum). Evidence floor:
+    # K>1 needs n>=50 (two clusters of ~25), n>=75 for K=3, etc. Below n=50 only
+    # K=1 — too few patients to claim distinct multivariate clusters. n=80 demo
+    # reaches K=3, n=125+ reaches K=5. K=1 is always in the search for the ΔBIC=6
+    # test against the no-cluster null.
+    max_k_by_size = max(1, min(5, n_patients // 25))
     max_n = min(max_k_by_size, n_patients - 1)
     # Diagonal covariance: PCA already decorrelates the global data, so
     # within-cluster off-diagonal terms tend to be small. Diagonal cuts each

--- a/gmm.py
+++ b/gmm.py
@@ -11,7 +11,7 @@ def fit_optimal_gmm(values: np.ndarray, delta_bic_threshold: float = 6.0) -> tup
     """
     Fit a GMM with BIC-optimal number of components.
 
-    Tries K = 1, 2, …, up to `min(4, n // 5)` — K>1 needs an evidence floor of
+    Tries K = 1, 2, …, up to `max(1, min(4, n // 5))` — K>1 needs an evidence floor of
     ~5 points per component (K=2 needs n≥10). Below that only K=1 is tried, so a
     handful of points can't be reported as "two groups". The best K (lowest BIC)
     only "wins" over K=1 if its BIC improvement exceeds `delta_bic_threshold`

--- a/gmm.py
+++ b/gmm.py
@@ -11,7 +11,9 @@ def fit_optimal_gmm(values: np.ndarray, delta_bic_threshold: float = 6.0) -> tup
     """
     Fit a GMM with BIC-optimal number of components.
 
-    Tries K = 1, 2, …, up to `min(4, max(2, n // 5))`. The best K (lowest BIC)
+    Tries K = 1, 2, …, up to `min(4, n // 5)` — K>1 needs an evidence floor of
+    ~5 points per component (K=2 needs n≥10). Below that only K=1 is tried, so a
+    handful of points can't be reported as "two groups". The best K (lowest BIC)
     only "wins" over K=1 if its BIC improvement exceeds `delta_bic_threshold`
     (default 6, the conventional "strong evidence" cutoff for BIC). Otherwise
     we fall back to K=1 — i.e. report a single Gaussian rather than overstate
@@ -20,7 +22,9 @@ def fit_optimal_gmm(values: np.ndarray, delta_bic_threshold: float = 6.0) -> tup
     Returns (gmm, n_components, bic_scores_dict). bic_scores_dict always
     contains an entry for K=1 so callers can show the comparison.
     """
-    max_n = min(4, max(2, len(values) // 5))
+    # Evidence floor: K>1 needs ~5 points per component (K=2 needs n>=10), so a
+    # handful of points can't be reported as "two groups". Below n=10 only K=1.
+    max_n = max(1, min(4, len(values) // 5))
     bic_scores: dict = {}
     fits: dict = {}
     for n in range(1, max_n + 1):

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -263,3 +263,20 @@ def test_strongest_marker_pair_single_marker():
         for i in range(20)
     ])
     assert strongest_marker_pair(df) is None
+
+
+def test_population_evidence_floor_small_cohort_reports_one_cluster(stub_df):
+    """L2 (#58): below ~50 patients (two clusters of ~25) the population fit
+    must report a single cluster, not split a small cohort into 'distinct' ones."""
+    keep = stub_df["patient_id"].drop_duplicates().head(40)
+    small = stub_df[stub_df["patient_id"].isin(keep)]
+    res = analyse_population(small)
+    assert "error" not in res
+    assert res["n_clusters"] == 1
+    assert max(res["bic_scores"]) == 1  # K=2 not even attempted below the floor
+
+
+def test_population_full_demo_still_reaches_two_clusters(stub_df):
+    """The n=80 demo is well above the floor and still finds its two subgroups."""
+    res = analyse_population(stub_df)
+    assert res["n_clusters"] == 2

--- a/tests/test_gmm_functions.py
+++ b/tests/test_gmm_functions.py
@@ -49,15 +49,23 @@ def test_trimodal_data_selects_3_components():
     assert n == 3
 
 
-def test_small_dataset_caps_max_k_at_2():
-    # 9 points → max_k_search = min(4, max(2, 9//5)) = 2.
-    # Random data with no real sub-structure should report K=1 thanks to the
-    # ΔBIC≥6 floor; the BIC dict still contains entries up to and including 2.
+def test_small_sample_reports_one_group_even_if_separated():
+    """Evidence floor (#58): below ~10 points, K=2 isn't even tried — a handful
+    of points can't be reported as "two groups", however clean the separation."""
     rng = np.random.default_rng(0)
-    values = rng.normal(10, 1, 9)
+    values = np.concatenate([rng.normal(10, 0.4, 4), rng.normal(30, 0.4, 4)])  # n=8
     _, n, bics = fit_optimal_gmm(values)
-    assert n in (1, 2)
-    assert max(bics) == 2
+    assert n == 1
+    assert max(bics) == 1   # K=2 not attempted below the floor
+
+
+def test_evidence_floor_allows_k2_at_n10():
+    """At n=10 (5 per component) K=2 becomes eligible and wins on clear data."""
+    rng = np.random.default_rng(0)
+    values = np.concatenate([rng.normal(10, 0.4, 5), rng.normal(30, 0.4, 5)])  # n=10
+    _, n, bics = fit_optimal_gmm(values)
+    assert 2 in bics
+    assert n == 2
 
 
 def test_uniform_data_selects_k1():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -129,6 +129,15 @@ def test_cohort_popover_closed_by_default_open_while_editing() -> None:
     assert not re.search(open_re, client.get("/filters/reset?tab=explorer").text)
 
 
+def test_below_evidence_floor_copy_is_honest() -> None:
+    """A cohort below the K>1 evidence floor must say only one cluster was
+    *evaluated* — not imply BIC compared candidates and chose it."""
+    # age 45-65 → 35 demo patients, below the 50-patient population floor
+    html = client.get("/?tab=population&age_min=45&age_max=65").text
+    assert "Only a single cluster was evaluated" in html
+    assert "Number of clusters selected by BIC" not in html
+
+
 # ── /tab/{name} partials ─────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("tab", ["explorer", "population", "investigate", "pairs"])

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -31,6 +31,18 @@ from web.state import (
 from analysis import most_separated_marker, strongest_marker_pair
 from unit_conversions import transform_for_display
 
+# How decisively a K>1 split beat the K=1 null. ΔBIC ≥ 6 is "strong evidence";
+# a margin only just past that floor is reported as tentative, not asserted.
+_DELTA_BIC_TENTATIVE = 10.0
+
+
+def _delta_bic(bic_scores: dict, n_chosen: int) -> float | None:
+    """ΔBIC of the chosen K vs the K=1 null. None when K=1 was chosen."""
+    if n_chosen <= 1 or 1 not in bic_scores or n_chosen not in bic_scores:
+        return None
+    return bic_scores[1] - bic_scores[n_chosen]
+
+
 # ── Marker explorer (Groups tab) ─────────────────────────────────────────────
 
 def _marker_context(data: dict, marker: str) -> dict | None:
@@ -79,6 +91,9 @@ def _marker_context(data: dict, marker: str) -> dict | None:
         "available":    available,
         "chart_html":   _marker_chart_html(data, marker),
         "bic_pairs":    sorted(res["bic_scores"].items()),
+        "delta_bic":    _delta_bic(res["bic_scores"], n_comp),
+        "tentative":    (d := _delta_bic(res["bic_scores"], n_comp)) is not None
+                        and d < _DELTA_BIC_TENTATIVE,
         "small_sample": res["small_sample"],
     }
 
@@ -170,6 +185,9 @@ def _population_context(data: dict, colour_by: str = "type") -> dict:
         "has_age":        has_age,
         "small_sample":   pop["small_sample"],
         "bic_pairs":      sorted(pop["bic_scores"].items()),
+        "delta_bic":      _delta_bic(pop["bic_scores"], n_clusters),
+        "tentative":      (d := _delta_bic(pop["bic_scores"], n_clusters)) is not None
+                          and d < _DELTA_BIC_TENTATIVE,
         "var_pct":        int(pop["pca_var"][:pop["n_cluster_dims"]].sum() * 100),
         "n_cluster_dims": pop["n_cluster_dims"],
     }

--- a/web/templates/partials/marker_explorer.html
+++ b/web/templates/partials/marker_explorer.html
@@ -62,12 +62,17 @@
 <details class="disclosure">
   <summary>Technical details</summary>
   <p class="t-meta">
-    Group count chosen by BIC scoring (lower = better fit):
-    {% for n, bic in e.bic_pairs %}
-      <strong>{{ n }} groups</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
-    {% endfor %}.
-    {{ e.n_components }} groups selected{% if e.delta_bic is not none %},
-      beating a single group by ΔBIC {{ "%.0f"|format(e.delta_bic) }}{% if e.tentative %}
-      — a marginal split, treat the sub-groups as tentative{% endif %}{% endif %}.
+    {% if e.bic_pairs|length == 1 %}
+      Only a single group was evaluated — too few values to test for sub-groups
+      (10+ needed). Reported as one group by default, not by BIC comparison.
+    {% else %}
+      Group count chosen by BIC scoring (lower = better fit):
+      {% for n, bic in e.bic_pairs %}
+        <strong>{{ n }} groups</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
+      {% endfor %}.
+      {{ e.n_components }} groups selected{% if e.delta_bic is not none %},
+        beating a single group by ΔBIC {{ "%.0f"|format(e.delta_bic) }}{% if e.tentative %}
+        — strong but not overwhelming evidence; treat the sub-groups as tentative{% endif %}{% endif %}.
+    {% endif %}
   </p>
 </details>

--- a/web/templates/partials/marker_explorer.html
+++ b/web/templates/partials/marker_explorer.html
@@ -66,6 +66,8 @@
     {% for n, bic in e.bic_pairs %}
       <strong>{{ n }} groups</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
     {% endfor %}.
-    {{ e.n_components }} groups selected.
+    {{ e.n_components }} groups selected{% if e.delta_bic is not none %},
+      beating a single group by ΔBIC {{ "%.0f"|format(e.delta_bic) }}{% if e.tentative %}
+      — a marginal split, treat the sub-groups as tentative{% endif %}{% endif %}.
   </p>
 </details>

--- a/web/templates/partials/population.html
+++ b/web/templates/partials/population.html
@@ -65,12 +65,18 @@
   <summary>Technical details</summary>
   <p class="t-meta">
     Analysis used {{ p.n_cluster_dims }} dimensions capturing {{ p.var_pct }}% of total variation.
-    Number of clusters selected by BIC (lower = better fit):
-    {% for n, bic in p.bic_pairs %}
-      <strong>{{ n }} clusters</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
-    {% endfor %}{% if p.delta_bic is not none %},
-      beating a single cluster by ΔBIC {{ "%.0f"|format(p.delta_bic) }}{% if p.tentative %}
-      — a marginal split, treat the clusters as tentative{% endif %}{% endif %}.
+    {% if p.bic_pairs|length == 1 %}
+      Only a single cluster was evaluated — {{ p.n_patients }} patients is below the
+      evidence floor (50+ needed to test for clusters). Reported as one cluster by
+      default, not by BIC comparison.
+    {% else %}
+      Number of clusters selected by BIC (lower = better fit):
+      {% for n, bic in p.bic_pairs %}
+        <strong>{{ n }} clusters</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
+      {% endfor %}{% if p.delta_bic is not none %},
+        beating a single cluster by ΔBIC {{ "%.0f"|format(p.delta_bic) }}{% if p.tentative %}
+        — strong but not overwhelming evidence; treat the clusters as tentative{% endif %}{% endif %}.
+    {% endif %}
   </p>
 </details>
 

--- a/web/templates/partials/population.html
+++ b/web/templates/partials/population.html
@@ -68,7 +68,9 @@
     Number of clusters selected by BIC (lower = better fit):
     {% for n, bic in p.bic_pairs %}
       <strong>{{ n }} clusters</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
-    {% endfor %}.
+    {% endfor %}{% if p.delta_bic is not none %},
+      beating a single cluster by ΔBIC {{ "%.0f"|format(p.delta_bic) }}{% if p.tentative %}
+      — a marginal split, treat the clusters as tentative{% endif %}{% endif %}.
   </p>
 </details>
 


### PR DESCRIPTION
Part of **Results integrity & honest confidence** (#5), audit findings **H2 + L2 + L3**.

## Why
"**2 natural groups**" could be reported on as few as 4 points: `fit_optimal_gmm` used `max_n = min(4, max(2, n//5))`, where the `max(2, …)` floor forced K=2 to be *tried* at any n; `analyse_population` was similarly permissive (n≥4). The ΔBIC≥6 floor only guards against the K=1 null — it doesn't stop a tiny sample being split. This bites the demo via any tight cohort filter.

## What changed
- **`gmm.py`** — K-range floor is now `max(1, min(4, n//5))`: K>1 needs ~5 points per component (K=2 needs n≥10, K=3 needs n≥15). Below that, only K=1 is even considered.
- **`analysis.py`** — population mirror: `max(1, min(5, n//25))`, so K>1 needs n≥50 (two clusters of ~25 — the documented per-cluster target). Below that, one cluster.
- **`web/contexts.py` + templates (L3)** — surface the winning **ΔBIC margin** in Technical details ("…beating a single group by ΔBIC N"), and flag a small margin (<10 over the K=1 null) as a **"marginal split — treat as tentative"**, so a borderline K reads as tentative rather than asserted.

Kept the locked decisions intact (ΔBIC≥6 threshold, diagonal covariance).

## Demo unaffected
n=80 is well above both floors — population still picks **K=2**, per-marker Ks unchanged, and **`demo_cache.pkl` is byte-identical** (no rebake needed).

## Tests
- A small but clearly-separated sample stays **K=1** (K=2 isn't even attempted); K=2 becomes eligible at **n=10**.
- A <50-patient cohort reports **one cluster**; the full demo still reaches **two**.
- `ruff check .` clean; full suite **259 passed**.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)