### PR TITLE
Make "strongest" findings honest: exclude derived markers, state the search size

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -194,16 +194,24 @@ def filter_long(
     return df_long[df_long["patient_id"].isin(kept_ids)].reset_index(drop=True)
 
 
+# Markers that are algebraically derived from other markers in the panel, so
+# they correlate / co-vary with their components by construction. Excluded from
+# the "strongest"/"clearest" auto-pick scans (they'd surface tautological
+# findings); still selectable manually in the dropdowns.
+DERIVED_MARKERS = frozenset({"Total Cholesterol:HDL Ratio"})
+
+
 def most_separated_marker(gmm_results: dict) -> tuple | None:
     """
     Return (marker_name, separation_score) for the marker with the
     most pronounced cluster separation. Score is the spread of cluster means
     measured in pooled-std units (Cohen's-d-style). Returns None if no marker
-    has at least two components.
+    has at least two components. Derived markers are excluded; iteration is
+    sorted so ties resolve deterministically.
     """
     best_name, best_score = None, -1.0
-    for name, res in gmm_results.items():
-        if "error" in res or res.get("n_components", 0) < 2:
+    for name, res in sorted(gmm_results.items()):
+        if name in DERIVED_MARKERS or "error" in res or res.get("n_components", 0) < 2:
             continue
         means = np.asarray(res["means"], dtype=float)
         stds  = np.asarray(res["stds"],  dtype=float)
@@ -222,11 +230,14 @@ def strongest_marker_pair(df_long: pd.DataFrame, min_overlap: int = 10) -> tuple
     """
     Return (marker_a, marker_b, r) for the pair of markers with the largest
     |Pearson r| in df_long, requiring at least `min_overlap` patients with both
-    measured. Returns None if no qualifying pair exists.
+    measured. Returns None if no qualifying pair exists. Derived markers are
+    excluded (they correlate with their components by construction); ties break
+    deterministically by marker name.
     """
     if df_long.empty:
         return None
     wide = df_long.pivot_table(index="patient_id", columns="test_name", values="value")
+    wide = wide.drop(columns=[m for m in DERIVED_MARKERS if m in wide.columns])
     if wide.shape[1] < 2:
         return None
 
@@ -239,6 +250,8 @@ def strongest_marker_pair(df_long: pd.DataFrame, min_overlap: int = 10) -> tuple
     flat = corr_no_diag.unstack().dropna()
     if flat.empty:
         return None
-    flat_abs = flat.abs().sort_values(ascending=False)
-    a, b = flat_abs.index[0]
+    # Sort by |r| desc, then by the (a, b) marker-name key so ties are stable
+    # regardless of the corr matrix's column order.
+    ranked = sorted(flat.items(), key=lambda kv: (-abs(kv[1]), kv[0]))
+    (a, b), _ = ranked[0]
     return str(a), str(b), float(corr.loc[a, b])

--- a/analysis.py
+++ b/analysis.py
@@ -200,6 +200,33 @@ def filter_long(
 # findings); still selectable manually in the dropdowns.
 DERIVED_MARKERS = frozenset({"Total Cholesterol:HDL Ratio"})
 
+# Markers bound by a structural identity, so a pair WITHIN a group correlates by
+# construction (Total Cholesterol ≈ HDL + LDL + ~0.45·Triglycerides; LDL is
+# often Friedewald-derived from the others). Such pairs are skipped by the
+# strongest-pair auto-pick — they'd be a less-obvious version of the same
+# tautology DERIVED_MARKERS guards against. (Only purely-algebraic cases; this
+# is a deliberately small, panel-specific list, not a general collinearity test.)
+_CONSTRAINT_GROUPS = (
+    frozenset({"Total Cholesterol", "LDL Cholesterol", "HDL Cholesterol"}),
+)
+
+
+def _same_constraint_group(a: str, b: str) -> bool:
+    return any({a, b} <= group for group in _CONSTRAINT_GROUPS)
+
+
+def n_comparable_pairs(markers) -> int:
+    """Count of candidate marker pairs the strongest-pair auto-pick considers:
+    unordered pairs of non-derived markers, excluding within-constraint-group
+    pairs. Upper bound on the search (before the min-overlap filter)."""
+    ms = [m for m in markers if m not in DERIVED_MARKERS]
+    return sum(
+        1
+        for i in range(len(ms))
+        for j in range(i + 1, len(ms))
+        if not _same_constraint_group(ms[i], ms[j])
+    )
+
 
 def most_separated_marker(gmm_results: dict) -> tuple | None:
     """
@@ -251,7 +278,10 @@ def strongest_marker_pair(df_long: pd.DataFrame, min_overlap: int = 10) -> tuple
     if flat.empty:
         return None
     # Sort by |r| desc, then by the (a, b) marker-name key so ties are stable
-    # regardless of the corr matrix's column order.
+    # regardless of the corr matrix's column order. Skip within-constraint-group
+    # pairs (structurally correlated → tautological headline).
     ranked = sorted(flat.items(), key=lambda kv: (-abs(kv[1]), kv[0]))
-    (a, b), _ = ranked[0]
-    return str(a), str(b), float(corr.loc[a, b])
+    for (a, b), _ in ranked:
+        if not _same_constraint_group(str(a), str(b)):
+            return str(a), str(b), float(corr.loc[a, b])
+    return None

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -292,6 +292,21 @@ def test_strongest_pair_excludes_derived_even_when_it_correlates_hardest():
     assert derived not in (a, b)
 
 
+def test_strongest_pair_skips_structurally_correlated_lipids():
+    """Total Cholesterol ↔ LDL/HDL correlate by the additive lipid identity, so
+    a genuine (cross-system) pair must headline instead — even when the lipid
+    pair has the higher |r|."""
+    base = [float(i) for i in range(20)]
+    df = _long_rows({
+        "Total Cholesterol": base,
+        "LDL Cholesterol":   [v + 0.001 for v in base],     # ~perfect (structural)
+        "SHBG":              [v * 0.85 + 2 for v in base],   # strong, genuine
+        "Albumin":           [v * 0.85 + 1 for v in base],
+    })
+    a, b, _ = strongest_marker_pair(df)
+    assert {a, b} != {"Total Cholesterol", "LDL Cholesterol"}
+
+
 def test_most_separated_excludes_derived():
     derived = next(iter(DERIVED_MARKERS))
     results = {

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from analysis import (
+    DERIVED_MARKERS,
     analyse_population,
     analyse_upload,
     build_labelled_df,
@@ -225,9 +226,10 @@ def test_most_separated_marker_returns_marker_with_clearest_split(stub_df):
     name, score = pick
     assert name in results
     assert score > 0
-    # All other multi-cluster markers should have score <= the picked one
+    assert name not in DERIVED_MARKERS
+    # All other multi-cluster, non-derived markers should score <= the picked one
     for _n, r in results.items():
-        if "error" in r or r.get("n_components", 0) < 2:
+        if _n in DERIVED_MARKERS or "error" in r or r.get("n_components", 0) < 2:
             continue
         pooled = float(np.mean(r["stds"]))
         if pooled <= 0:
@@ -263,6 +265,52 @@ def test_strongest_marker_pair_single_marker():
         for i in range(20)
     ])
     assert strongest_marker_pair(df) is None
+
+
+# ── Derived-marker exclusion + deterministic selection (#59) ──────────────────
+
+def _long_rows(by_marker: dict[str, list[float]]) -> pd.DataFrame:
+    rows = []
+    for marker, vals in by_marker.items():
+        for i, v in enumerate(vals):
+            rows.append({"patient_id": f"P{i}", "age": 40,
+                         "test_name": marker, "value": v, "unit": "x"})
+    return pd.DataFrame(rows)
+
+
+def test_strongest_pair_excludes_derived_even_when_it_correlates_hardest():
+    """A derived marker that perfectly tracks its component must not be the
+    headline pair — it's tautological."""
+    base = [float(i) for i in range(20)]
+    derived = next(iter(DERIVED_MARKERS))
+    df = _long_rows({
+        "Total Cholesterol": base,
+        derived:             [v * 1.0001 for v in base],   # ~perfect corr (tautology)
+        "SHBG":              [v * 0.8 + 3 for v in base],   # strong but genuine
+    })
+    a, b, _ = strongest_marker_pair(df)
+    assert derived not in (a, b)
+
+
+def test_most_separated_excludes_derived():
+    derived = next(iter(DERIVED_MARKERS))
+    results = {
+        "Albumin": {"n_components": 2, "means": np.array([1.0, 3.0]),
+                    "stds": np.array([0.5, 0.5])},
+        derived:   {"n_components": 2, "means": np.array([0.0, 99.0]),
+                    "stds": np.array([0.5, 0.5])},
+    }
+    name, _ = most_separated_marker(results)
+    assert name == "Albumin"   # the bigger-separation derived marker is skipped
+
+
+def test_strongest_pair_tiebreak_is_deterministic():
+    """When several pairs tie on |r|, the winner is a stable alphabetical key,
+    not whatever the corr-matrix / insertion order happens to be."""
+    base = [float(i) for i in range(15)]
+    df = _long_rows({"CCC": base, "AAA": list(base), "BBB": list(base)})  # all r=1.0
+    a, b, _ = strongest_marker_pair(df)
+    assert (a, b) == ("AAA", "BBB")   # alphabetical, regardless of insert order
 
 
 def test_population_evidence_floor_small_cohort_reports_one_cluster(stub_df):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -129,6 +129,14 @@ def test_cohort_popover_closed_by_default_open_while_editing() -> None:
     assert not re.search(open_re, client.get("/filters/reset?tab=explorer").text)
 
 
+def test_no_auto_pick_claim_when_no_marker_has_a_split() -> None:
+    """A tiny cohort where every marker is K=1 must not render
+    'auto-picked: clearest of 0 markers' — there's no auto-pick to claim."""
+    html = client.get("/?tab=explorer&age_min=64&age_max=65").text  # 4 demo patients
+    assert "clearest of 0" not in html
+    assert "auto-picked" not in html
+
+
 def test_below_evidence_floor_copy_is_honest() -> None:
     """A cohort below the K>1 evidence floor must say only one cluster was
     *evaluated* — not imply BIC compared candidates and chose it."""

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -28,7 +28,7 @@ from web.state import (
     state,
 )
 
-from analysis import most_separated_marker, strongest_marker_pair
+from analysis import DERIVED_MARKERS, most_separated_marker, strongest_marker_pair
 from unit_conversions import transform_for_display
 
 # How decisively a K>1 split beat the K=1 null. ΔBIC ≥ 6 is "strong evidence";
@@ -78,11 +78,18 @@ def _marker_context(data: dict, marker: str) -> dict | None:
 
     pick = most_separated_marker(data["gmm_results"])
     auto_choice = pick[0] if pick else available[0]
+    # How many markers the "clearest split" auto-pick ranked over (K≥2,
+    # non-derived) — so the UI can say "clearest of N", not "the clearest".
+    n_auto_candidates = sum(
+        1 for nm, r in data["gmm_results"].items()
+        if nm not in DERIVED_MARKERS and "error" not in r and r.get("n_components", 0) >= 2
+    )
 
     return {
         "marker":       marker,
         "auto_choice":  auto_choice,
         "is_auto":      marker == auto_choice,
+        "n_auto_candidates": n_auto_candidates,
         "n_components": n_comp,
         "n_patients":   data["df_long"]["patient_id"].nunique(),
         "n_markers":    data["df_long"]["test_name"].nunique(),
@@ -298,6 +305,10 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
 
     showing_auto = auto_pair is not None and {x, y} == {auto_pair[0], auto_pair[1]}
     n_overlap = len(wide)
+    # Size of the search the auto-pick won, so the UI can say "strongest of N
+    # pairs" rather than presenting it as a singular discovery.
+    n_comparable = len([m for m in markers_in_data if m not in DERIVED_MARKERS])
+    n_pairs_searched = n_comparable * (n_comparable - 1) // 2
 
     if r is not None:
         strength_word = (
@@ -317,6 +328,7 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
         "y_options":     [m for m in markers_in_data if m != x],
         "r":             r,
         "showing_auto":  showing_auto,
+        "n_pairs_searched": n_pairs_searched,
         "strength_word": strength_word,
         "dir_word":      dir_word,
         "track":         track,

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -28,7 +28,12 @@ from web.state import (
     state,
 )
 
-from analysis import DERIVED_MARKERS, most_separated_marker, strongest_marker_pair
+from analysis import (
+    DERIVED_MARKERS,
+    most_separated_marker,
+    n_comparable_pairs,
+    strongest_marker_pair,
+)
 from unit_conversions import transform_for_display
 
 # How decisively a K>1 split beat the K=1 null. ΔBIC ≥ 6 is "strong evidence";
@@ -305,10 +310,10 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
 
     showing_auto = auto_pair is not None and {x, y} == {auto_pair[0], auto_pair[1]}
     n_overlap = len(wide)
-    # Size of the search the auto-pick won, so the UI can say "strongest of N
-    # pairs" rather than presenting it as a singular discovery.
-    n_comparable = len([m for m in markers_in_data if m not in DERIVED_MARKERS])
-    n_pairs_searched = n_comparable * (n_comparable - 1) // 2
+    # Size of the search the auto-pick won, so the UI can frame it as the
+    # strongest of many candidate pairs rather than a singular discovery. This
+    # is the candidate count (before the min-overlap filter), labelled as such.
+    n_pairs_searched = n_comparable_pairs(markers_in_data)
 
     if r is not None:
         strength_word = (

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -93,7 +93,10 @@ def _marker_context(data: dict, marker: str) -> dict | None:
     return {
         "marker":       marker,
         "auto_choice":  auto_choice,
-        "is_auto":      marker == auto_choice,
+        # Only a genuine "clearest split" pick counts as auto — when no marker
+        # has a split (pick is None) the fallback is just the first marker, not
+        # an auto-pick, so we don't claim "clearest of 0 markers".
+        "is_auto":      pick is not None and marker == pick[0],
         "n_auto_candidates": n_auto_candidates,
         "n_components": n_comp,
         "n_patients":   data["df_long"]["patient_id"].nunique(),

--- a/web/templates/partials/_controls_explorer.html
+++ b/web/templates/partials/_controls_explorer.html
@@ -15,6 +15,6 @@
     {% endfor %}
   </select>
   <span class="toolbar-status">
-    {% if e.is_auto %}auto-picked: clearest of {{ e.n_auto_candidates }} markers &nbsp;·&nbsp; {% endif %}{{ e.n_components }} groups · {{ e.n_patients }} tests
+    {% if e.is_auto %}auto-picked: clearest of {{ e.n_auto_candidates }} markers with a split &nbsp;·&nbsp; {% endif %}{{ e.n_components }} groups · {{ e.n_patients }} tests
   </span>
 </div>

--- a/web/templates/partials/_controls_explorer.html
+++ b/web/templates/partials/_controls_explorer.html
@@ -15,6 +15,6 @@
     {% endfor %}
   </select>
   <span class="toolbar-status">
-    {% if e.is_auto %}auto-picked: clearest split &nbsp;·&nbsp; {% endif %}{{ e.n_components }} groups · {{ e.n_patients }} tests
+    {% if e.is_auto %}auto-picked: clearest of {{ e.n_auto_candidates }} markers &nbsp;·&nbsp; {% endif %}{{ e.n_components }} groups · {{ e.n_patients }} tests
   </span>
 </div>

--- a/web/templates/partials/_controls_pairs.html
+++ b/web/templates/partials/_controls_pairs.html
@@ -28,7 +28,7 @@
   </select>
   {% if q.r is not none %}
     <span class="toolbar-status">
-      {% if q.showing_auto %}auto-picked: strongest pair &nbsp;·&nbsp; {% endif %}r = {{ "%+.2f"|format(q.r) }} · {{ q.n_overlap }} tests
+      {% if q.showing_auto %}auto-picked: strongest of {{ q.n_pairs_searched }} pairs &nbsp;·&nbsp; {% endif %}r = {{ "%+.2f"|format(q.r) }} · {{ q.n_overlap }} tests
     </span>
   {% endif %}
 </div>

--- a/web/templates/partials/_controls_pairs.html
+++ b/web/templates/partials/_controls_pairs.html
@@ -28,7 +28,7 @@
   </select>
   {% if q.r is not none %}
     <span class="toolbar-status">
-      {% if q.showing_auto %}auto-picked: strongest of {{ q.n_pairs_searched }} pairs &nbsp;·&nbsp; {% endif %}r = {{ "%+.2f"|format(q.r) }} · {{ q.n_overlap }} tests
+      {% if q.showing_auto %}auto-picked: strongest of {{ q.n_pairs_searched }} candidate pairs &nbsp;·&nbsp; {% endif %}r = {{ "%+.2f"|format(q.r) }} · {{ q.n_overlap }} tests
     </span>
   {% endif %}
 </div>


### PR DESCRIPTION
Part of **Results integrity & honest confidence** (#5), audit findings **H3 + L4**.

## Why
The auto-picks presented a single maximum as *the* finding, with no sense of how large a search produced it — and they included an **algebraically-derived** marker. `Total Cholesterol:HDL Ratio` is a ratio of two other panel markers, so it correlates with them **by construction**; it was the demo's auto-picked "strongest pair," i.e. a tautology presented as a discovery.

## What changed
- **`analysis.py`** — `DERIVED_MARKERS = {"Total Cholesterol:HDL Ratio"}`, excluded from both auto-pick scans (`most_separated_marker`, `strongest_marker_pair`). It's still **selectable manually** in the X/Y and marker dropdowns — only the *headline* auto-pick avoids it.
- **Deterministic selection (L4)** — `strongest_marker_pair` breaks |r| ties by the `(a, b)` marker-name key; `most_separated_marker` iterates sorted. Neither depends on dict / corr-matrix column order anymore.
- **Honest copy** — the toolbar status now reads **"clearest of N markers"** and **"strongest of N pairs"** (counts from `web/contexts.py`), so the result reads as a maximum-of-many rather than a singular discovery. Verified: "strongest of 351 pairs", "clearest of 6 markers".

## Scope note (kept proportionate)
Excluded the one derived marker and stated the search size — did **not** build app-wide FDR/permutation testing (out of scope, and the "of N" framing is the honest, low-complexity win). Locked decisions untouched.

## Effect on the demo
Auto-picks change as intended (strongest pair is now LDL Cholesterol ↔ SHBG, not the ratio). `demo_cache.pkl` is **byte-identical** — auto-picks are computed at request time, not baked.

## Tests
- A derived marker never wins the pair scan even when it correlates hardest, nor the separation scan when it separates hardest.
- |r| tie-break is deterministic (alphabetical), independent of insertion order.
- `ruff check .` clean; full suite **263 passed**.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)