### PR TITLE
Robust correlation: cross-check Pearson with Spearman

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -243,6 +243,48 @@ def test_population_scatter_invalid_colour_by_defaults_to_type() -> None:
     assert "Cluster 1" in garbage.text and "Age" not in garbage.text
 
 
+# ── Correlation robustness (#61) ──────────────────────────────────────────────
+
+def _pair_df(x_vals, y_vals, xm="ALT", ym="ALP"):
+    rows = []
+    for i, (xv, yv) in enumerate(zip(x_vals, y_vals, strict=True)):
+        rows.append({"patient_id": f"P{i}", "age": 40, "test_name": xm,
+                     "value": float(xv), "unit": "U/L"})
+        rows.append({"patient_id": f"P{i}", "age": 40, "test_name": ym,
+                     "value": float(yv), "unit": "U/L"})
+    return pd.DataFrame(rows)
+
+
+def test_pair_flags_pearson_spearman_divergence() -> None:
+    """A single bivariate outlier makes Pearson and Spearman disagree → flagged."""
+    from web.contexts import _pair_context
+
+    x = list(range(15))
+    y = list(range(15))
+    y[0] = 1000  # outlier: low x, huge y — wrecks Pearson, dents Spearman less
+    ctx = _pair_context({"df_long": _pair_df(x, y), "pop_results": {}}, "ALT", "ALP")
+    assert ctx["diverges"] is True
+    assert abs(ctx["r"] - ctx["rho"]) > 0.2
+
+
+def test_pair_strong_claim_requires_enough_overlap() -> None:
+    """A clean correlation on too few points is flagged low-overlap (tentative)."""
+    from web.contexts import _pair_context
+
+    x = list(range(15))                      # n=15 < the 25-point "strong" floor
+    ctx = _pair_context({"df_long": _pair_df(x, x), "pop_results": {}}, "ALT", "ALP")
+    assert ctx["low_overlap"] is True
+
+
+def test_pair_clean_large_sample_not_flagged() -> None:
+    from web.contexts import _pair_context
+
+    x = [float(i) for i in range(30)]        # perfect linear, n=30 ≥ floor
+    ctx = _pair_context({"df_long": _pair_df(x, x), "pop_results": {}}, "ALT", "ALP")
+    assert ctx["low_overlap"] is False
+    assert ctx["diverges"] is False
+
+
 # ── /pair partial ────────────────────────────────────────────────────────────
 
 def test_pair_partial_no_params_picks_strongest_pair() -> None:

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -40,6 +40,12 @@ from unit_conversions import transform_for_display
 # a margin only just past that floor is reported as tentative, not asserted.
 _DELTA_BIC_TENTATIVE = 10.0
 
+# Correlation robustness (M3): |Pearson − Spearman| above this signals an
+# outlier / non-linear shape; a "strong" claim needs at least this many paired
+# points (r from ~10 points has a very wide confidence interval).
+_CORR_DIVERGENCE = 0.2
+_STRONG_MIN_OVERLAP = 25
+
 
 def _delta_bic(bic_scores: dict, n_chosen: int) -> float | None:
     """ΔBIC of the chosen K vs the K=1 null. None when K=1 was chosen."""
@@ -328,11 +334,17 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
     )
     if len(wide) >= 4 and x in wide.columns and y in wide.columns:
         r = float(wide[x].corr(wide[y]))
+        rho = float(wide[x].corr(wide[y], method="spearman"))   # rank, outlier-robust
     else:
-        r = None
+        r = rho = None
 
     showing_auto = auto_pair is not None and {x, y} == {auto_pair[0], auto_pair[1]}
     n_overlap = len(wide)
+    # Robustness signals (M3): a large Pearson↔Spearman gap means a single
+    # bivariate outlier or a non-linear shape is inflating/deflating Pearson;
+    # and a "strong" claim needs more than the 10-point scan floor to be trusted.
+    diverges = r is not None and rho is not None and abs(r - rho) > _CORR_DIVERGENCE
+    low_overlap = r is not None and n_overlap < _STRONG_MIN_OVERLAP
     # Size of the search the auto-pick won, so the UI can frame it as the
     # strongest of many candidate pairs rather than a singular discovery. This
     # is the candidate count (before the min-overlap filter), labelled as such.
@@ -355,6 +367,9 @@ def _pair_context(data: dict, x: str | None, y: str | None) -> dict:
         "y":             y,
         "y_options":     [m for m in markers_in_data if m != x],
         "r":             r,
+        "rho":           rho,
+        "diverges":      diverges,
+        "low_overlap":   low_overlap,
         "showing_auto":  showing_auto,
         "n_pairs_searched": n_pairs_searched,
         "strength_word": strength_word,

--- a/web/templates/partials/pairs.html
+++ b/web/templates/partials/pairs.html
@@ -10,7 +10,13 @@
     {{ q.strength_word }} {{ q.dir_word }} correlation between
     <strong>{{ q.x }}</strong> and <strong>{{ q.y }}</strong>
     across {{ q.n_overlap }} tests.
-    {% if q.r|abs > 0.3 %}
+    {% if q.diverges %}
+      Rank correlation (ρ = {{ "%+.2f"|format(q.rho) }}) differs from Pearson —
+      likely a bivariate outlier or a non-linear shape, so r overstates the linear fit.
+    {% elif q.low_overlap %}
+      On only {{ q.n_overlap }} tests, treat even this as tentative — r from a small
+      sample has a wide confidence interval.
+    {% elif q.r|abs > 0.3 %}
       Knowing one tells you something about the other.
     {% else %}
       The two markers move largely independently in this cohort.


### PR DESCRIPTION
Part of **Results integrity & honest confidence** (#5), audit finding **M3**.

## Why
Correlations were **Pearson-only**, and "strong" (|r|>0.6) was claimed on as few as ~10 paired points. A single bivariate outlier can manufacture or destroy a strong r, a monotone-non-linear relationship is understated, and r from n≈10 has a very wide confidence interval.

## What changed
- `_pair_context` now computes **Spearman (rank) alongside Pearson** and exposes two robustness signals:
  - **`diverges`** — `|Pearson − Spearman| > 0.2`: a bivariate outlier or non-linear shape is distorting the linear r.
  - **`low_overlap`** — fewer than **25** paired points (raised well above the 10-point scan floor) → a "strong" claim isn't trustworthy.
- The Correlations finding surfaces these honestly: a divergence note showing ρ and warning that r overstates the linear fit, or a small-sample "treat as tentative" note. Otherwise the existing confident phrasing stands.

## Scope (kept tight)
Pearson stays the primary metric (per the issue); this adds a cross-check + caveats, no new chart types.

## Display-only
Web-layer only — `analysis.py` untouched, so `demo_cache.pkl` is unchanged. On the demo (n=80, clean strong pairs) neither caveat fires; they appear only when warranted.

## Tests
- An injected outlier triggers `diverges` (and `|r − ρ| > 0.2`).
- A clean n=15 pair is `low_overlap`; a clean n=30 pair is flagged neither.
- `ruff check .` clean; full suite **273 passed**.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)