### PR TITLE
Parse CSV values with thousands separators

### DIFF
--- a/parsing.py
+++ b/parsing.py
@@ -39,7 +39,9 @@ def parse_csv(
                        forced, units}.
     """
     overrides = unit_overrides or {}
-    df_raw = pd.read_csv(source)
+    # thousands="," so values like "1,366.00" parse as 1366.0 — real-world lab
+    # exports commonly format large numbers with a thousands separator.
+    df_raw = pd.read_csv(source, thousands=",")
     df_raw = df_raw[
         df_raw[ID_COLUMN].notna()
         & (df_raw[ID_COLUMN].astype(str).str.strip() != "")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -598,6 +598,25 @@ def test_upload_happy_path_replaces_demo_state() -> None:
     assert state.df_long_full["patient_id"].nunique() == 5
 
 
+def test_upload_handles_thousands_separators() -> None:
+    """Values like '1,366.00' (thousands separator) must parse, not 500."""
+    rows = []
+    for i in range(5):
+        rows.append({
+            "Blood Test Info Blood Test ID":     f"P{i:03d}",
+            "Current Age":                       str(40 + i),
+            "Blood Test Info Ferritin Levels":   '"1,366.00"',
+            "Blood Test Info Albumin Levels":    str(42 + i),
+        })
+    res = client.post(
+        "/upload",
+        files={"file": ("commas.csv", io.BytesIO(_csv_bytes(rows)), "text/csv")},
+    )
+    assert res.status_code == 200
+    assert res.headers.get("HX-Redirect") == "/"   # parsed, not an inline error
+    assert state.df_long_full.query("test_name == 'Ferritin'")["value"].max() == 1366.0
+
+
 def test_upload_surfaces_detected_units() -> None:
     """After an upload, the rail shows the inferred source unit per marker.
     The fixture's HbA1C values (~5%) are detected as % and converted."""


### PR DESCRIPTION
## The bug
A real upload failed with:
```
Could not read CSV: could not convert string to float: '1,366.00'
```
`read_csv` left the thousands separator in the value, and the per-column `float()` conversion choked. Lab exports routinely format large numbers like `1,366.00`.

## Fix
`pd.read_csv(source, thousands=",")` — pandas now parses `1,366.00` as `1366.0`. One line, no behavioural change for comma-free CSVs (the demo is generated in-memory, unaffected).

## Verification
- Repro now parses: Ferritin `"1,366.00"` → `1366.0`.
- Regression test added (`test_upload_handles_thousands_separators`).
- `ruff check .` clean; full suite **279 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)