### PR TITLE
Simplify the Groups toolbar

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -160,12 +160,13 @@ def test_investigate_sets_aside_and_annotates_imputed_patients() -> None:
     assert p2["imputed_pct"] == 30                      # partial imputation annotated
 
 
-def test_no_auto_pick_claim_when_no_marker_has_a_split() -> None:
-    """A tiny cohort where every marker is K=1 must not render
-    'auto-picked: clearest of 0 markers' — there's no auto-pick to claim."""
-    html = client.get("/?tab=explorer&age_min=64&age_max=65").text  # 4 demo patients
-    assert "clearest of 0" not in html
-    assert "auto-picked" not in html
+def test_groups_toolbar_is_simplified() -> None:
+    """The Groups toolbar is just the marker picker — no 'Showing' label and no
+    'auto-picked … N groups · N tests' status text."""
+    html = client.get("/?tab=explorer").text
+    assert 'id="marker-picker"' in html          # the picker stays
+    assert "Showing" not in html                 # label removed
+    assert "auto-picked" not in html             # status text removed
 
 
 def test_below_evidence_floor_copy_is_honest() -> None:

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -29,7 +29,6 @@ from web.state import (
 )
 
 from analysis import (
-    DERIVED_MARKERS,
     HEAVY_IMPUTE_FRAC,
     most_separated_marker,
     n_comparable_pairs,
@@ -88,23 +87,8 @@ def _marker_context(data: dict, marker: str) -> dict | None:
         key=lambda g: -g["weight"],
     )
 
-    pick = most_separated_marker(data["gmm_results"])
-    auto_choice = pick[0] if pick else available[0]
-    # How many markers the "clearest split" auto-pick ranked over (K≥2,
-    # non-derived) — so the UI can say "clearest of N", not "the clearest".
-    n_auto_candidates = sum(
-        1 for nm, r in data["gmm_results"].items()
-        if nm not in DERIVED_MARKERS and "error" not in r and r.get("n_components", 0) >= 2
-    )
-
     return {
         "marker":       marker,
-        "auto_choice":  auto_choice,
-        # Only a genuine "clearest split" pick counts as auto — when no marker
-        # has a split (pick is None) the fallback is just the first marker, not
-        # an auto-pick, so we don't claim "clearest of 0 markers".
-        "is_auto":      pick is not None and marker == pick[0],
-        "n_auto_candidates": n_auto_candidates,
         "n_components": n_comp,
         "n_patients":   data["df_long"]["patient_id"].nunique(),
         "n_markers":    data["df_long"]["test_name"].nunique(),

--- a/web/templates/partials/_controls_explorer.html
+++ b/web/templates/partials/_controls_explorer.html
@@ -1,9 +1,9 @@
 {% set e = explorer %}
 <div class="toolbar-control">
-  <label for="marker-picker">Showing</label>
   <select
     id="marker-picker"
     name="name"
+    aria-label="Marker"
     hx-get="/marker{% if filter_qs %}?{{ filter_qs }}{% endif %}"
     hx-trigger="change"
     hx-target="#page-body"
@@ -14,7 +14,4 @@
       <option value="{{ m }}" {% if m == e.marker %}selected{% endif %}>{{ m }}</option>
     {% endfor %}
   </select>
-  <span class="toolbar-status">
-    {% if e.is_auto %}auto-picked: clearest of {{ e.n_auto_candidates }} markers with a split &nbsp;·&nbsp; {% endif %}{{ e.n_components }} groups · {{ e.n_patients }} tests
-  </span>
 </div>


### PR DESCRIPTION
## What
On the Groups tab, removed two space-hungry bits of toolbar chrome (per request):
- the **"auto-picked: clearest of N markers with a split · N groups · N tests"** status text;
- the **"Showing"** label before the marker selector.

The marker picker stays (with an `aria-label="Marker"` for accessibility now that the visible label is gone). The group count and test count still appear in the chart legend and the `.finding` summary below, so no information is lost.

## Cleanup
The status text was the only consumer of `is_auto` / `auto_choice` / `n_auto_candidates`, so those dead context fields are removed, along with the now-unused `DERIVED_MARKERS` import in `web/contexts.py`. (The default-marker selection still uses `most_separated_marker` in `_build_tab_ctx` — untouched.)

## Verification
- Screenshot: the Groups toolbar is now just the marker dropdown + the Cohort chip + ⓘ.
- Repurposed the now-vacuous auto-pick test into `test_groups_toolbar_is_simplified` (picker present; no "Showing", no "auto-picked").
- `ruff check .` clean; full suite **279 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)