### PR TITLE
Tidy the tab views: plain-English banners above each graph

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -170,12 +170,11 @@ def test_groups_toolbar_is_simplified() -> None:
 
 
 def test_below_evidence_floor_copy_is_honest() -> None:
-    """A cohort below the K>1 evidence floor must say only one cluster was
-    *evaluated* — not imply BIC compared candidates and chose it."""
+    """A cohort below the K>1 evidence floor must say there are too few tests to
+    look for groups — not imply clusters were found and compared."""
     # age 45-65 → 35 demo patients, below the 50-patient population floor
     html = client.get("/?tab=population&age_min=45&age_max=65").text
-    assert "Only a single cluster was evaluated" in html
-    assert "Number of clusters selected by BIC" not in html
+    assert "too few tests here to look for separate groups" in html
 
 
 # ── /tab/{name} partials ─────────────────────────────────────────────────────

--- a/web/contexts.py
+++ b/web/contexts.py
@@ -97,7 +97,6 @@ def _marker_context(data: dict, marker: str) -> dict | None:
         "available":    available,
         "chart_html":   _marker_chart_html(data, marker),
         "bic_pairs":    sorted(res["bic_scores"].items()),
-        "delta_bic":    _delta_bic(res["bic_scores"], n_comp),
         "tentative":    (d := _delta_bic(res["bic_scores"], n_comp)) is not None
                         and d < _DELTA_BIC_TENTATIVE,
         "small_sample": res["small_sample"],
@@ -129,7 +128,6 @@ def _population_context(data: dict, colour_by: str = "type") -> dict:
     fp = pop["fingerprint"].round(2)
 
     types: list[dict] = []
-    sub_summaries: list[str] = []
     for g in range(n_clusters):
         col = fp[f"Group {g + 1}"]
         col_sorted = col.abs().sort_values(ascending=False)
@@ -168,33 +166,18 @@ def _population_context(data: dict, colour_by: str = "type") -> dict:
             "bullets":    bullets,
         })
 
-        top_marker = col_sorted.index[0] if len(col_sorted) else None
-        if top_marker is not None:
-            top_z = float(col[top_marker])
-            top_dir = "higher" if top_z > 0 else "lower"
-            age_bit = f", median age {median_age}" if median_age is not None else ""
-            sub_summaries.append(
-                f"<strong>Cluster {g + 1}</strong> ({len(members)} tests{age_bit}) "
-                f"— most distinct in <strong>{top_marker}</strong> ({top_dir} than average)"
-            )
-
     return {
         "n_patients":     n_patients,
         "n_clusters":     n_clusters,
-        "n_markers":      pop["df_wide"].shape[1],
-        "type_word":      "cluster" if n_clusters == 1 else "distinct clusters",
         "types":          types,
-        "sub_summaries":  sub_summaries,
         "scatter_html":   _population_scatter_html(data, colour_by),
         "heatmap_html":   _heatmap_html(data),
         "colour_by":      colour_by,
         "has_age":        has_age,
         "small_sample":   pop["small_sample"],
         "bic_pairs":      sorted(pop["bic_scores"].items()),
-        "delta_bic":      _delta_bic(pop["bic_scores"], n_clusters),
         "tentative":      (d := _delta_bic(pop["bic_scores"], n_clusters)) is not None
                           and d < _DELTA_BIC_TENTATIVE,
-        "var_pct":        int(pop["pca_var"][:pop["n_cluster_dims"]].sum() * 100),
         "n_cluster_dims": pop["n_cluster_dims"],
     }
 

--- a/web/templates/partials/_controls_pairs.html
+++ b/web/templates/partials/_controls_pairs.html
@@ -26,9 +26,4 @@
       <option value="{{ m }}" {% if m == q.y %}selected{% endif %}>{{ m }}</option>
     {% endfor %}
   </select>
-  {% if q.r is not none %}
-    <span class="toolbar-status">
-      {% if q.showing_auto %}auto-picked: strongest of {{ q.n_pairs_searched }} candidate pairs &nbsp;·&nbsp; {% endif %}r = {{ "%+.2f"|format(q.r) }} · {{ q.n_overlap }} tests
-    </span>
-  {% endif %}
 </div>

--- a/web/templates/partials/_controls_population.html
+++ b/web/templates/partials/_controls_population.html
@@ -13,6 +13,5 @@
     <option value="type" {% if p.colour_by == "type" %}selected{% endif %}>Cluster</option>
     <option value="age"  {% if p.colour_by == "age"  %}selected{% endif %}>Age</option>
   </select>
-  <span class="toolbar-status">{{ p.n_patients }} blood tests · {{ p.n_markers }} markers used</span>
 </div>
 {% endif %}

--- a/web/templates/partials/marker_explorer.html
+++ b/web/templates/partials/marker_explorer.html
@@ -2,20 +2,28 @@
 {% set biggest = e.groups[0] %}
 {% set second  = e.groups[1] if e.groups|length > 1 else none %}
 
-<div class="chart-host">
-  {{ e.chart_html | safe }}
-</div>
-
 <div class="finding">
   {% if e.n_components >= 2 and second %}
-    <strong>{{ e.n_components }} natural groups</strong> in {{ e.marker }}.
-    Largest ({{ "%.0f"|format(biggest.percent) }}% of tests) around
-    <strong>{{ "%.2f"|format(biggest.mean) }} {{ e.disp_unit }}</strong>;
-    next ({{ "%.0f"|format(second.percent) }}%) around
+    Your {{ e.marker }} results split into <strong>{{ e.n_components }} groups</strong>.
+    Most ({{ "%.0f"|format(biggest.percent) }}%) sit around
+    <strong>{{ "%.2f"|format(biggest.mean) }} {{ e.disp_unit }}</strong>, and
+    {{ "%.0f"|format(second.percent) }}% sit around
     <strong>{{ "%.2f"|format(second.mean) }} {{ e.disp_unit }}</strong>.
+    Each curve on the chart is one group.
+    {% if e.tentative %}
+      The split is on the weak side, so treat the groups as tentative.
+    {% endif %}
+  {% elif e.bic_pairs|length == 1 %}
+    There are too few {{ e.marker }} results here to check for separate groups,
+    so they're shown as one.
   {% else %}
-    <strong>Uniform</strong> across all tests &mdash; no clear sub-groups in {{ e.marker }}.
+    Your {{ e.marker }} results form one smooth spread. They don't separate into
+    distinct groups.
   {% endif %}
+</div>
+
+<div class="chart-host">
+  {{ e.chart_html | safe }}
 </div>
 
 <div class="group-grid">
@@ -57,22 +65,4 @@
       {% endfor %}
     </tbody>
   </table>
-</details>
-
-<details class="disclosure">
-  <summary>Technical details</summary>
-  <p class="t-meta">
-    {% if e.bic_pairs|length == 1 %}
-      Only a single group was evaluated — too few values to test for sub-groups
-      (10+ needed). Reported as one group by default, not by BIC comparison.
-    {% else %}
-      Group count chosen by BIC scoring (lower = better fit):
-      {% for n, bic in e.bic_pairs %}
-        <strong>{{ n }} groups</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
-      {% endfor %}.
-      {{ e.n_components }} groups selected{% if e.delta_bic is not none %},
-        beating a single group by ΔBIC {{ "%.0f"|format(e.delta_bic) }}{% if e.tentative %}
-        — strong but not overwhelming evidence; treat the sub-groups as tentative{% endif %}{% endif %}.
-    {% endif %}
-  </p>
 </details>

--- a/web/templates/partials/pairs.html
+++ b/web/templates/partials/pairs.html
@@ -1,29 +1,27 @@
 {% set q = pair %}
 
-<div class="chart-host">
-  {{ q.chart_html | safe }}
-</div>
-
 <div class="finding">
   {% if q.r is not none %}
-    <strong>r = {{ "%+.2f"|format(q.r) }}</strong> &mdash;
-    {{ q.strength_word }} {{ q.dir_word }} correlation between
-    <strong>{{ q.x }}</strong> and <strong>{{ q.y }}</strong>
-    across {{ q.n_overlap }} tests.
-    {% if q.diverges %}
-      Rank correlation (ρ = {{ "%+.2f"|format(q.rho) }}) differs from Pearson —
-      likely a bivariate outlier or a non-linear shape, so r overstates the linear fit.
-    {% elif q.low_overlap %}
-      On only {{ q.n_overlap }} tests, treat even this as tentative — r from a small
-      sample has a wide confidence interval.
-    {% elif q.r|abs > 0.3 %}
-      Knowing one tells you something about the other.
+    Each dot is one blood test.
+    {% if q.r|abs > 0.3 %}
+      As {{ q.x }} goes up, {{ q.y }} tends to go {{ "up too" if q.r > 0 else "down" }}
+      ({{ q.strength_word }} link, r = {{ "%+.2f"|format(q.r) }} across {{ q.n_overlap }} tests).
     {% else %}
-      The two markers move largely independently in this cohort.
+      {{ q.x }} and {{ q.y }} don't really move together here
+      (r = {{ "%+.2f"|format(q.r) }} across {{ q.n_overlap }} tests).
+    {% endif %}
+    {% if q.diverges %}
+      A few unusual points are skewing this: a rank-based check (ρ = {{ "%+.2f"|format(q.rho) }})
+      disagrees with the straight-line r, so don't read too much into it.
+    {% elif q.low_overlap %}
+      Only {{ q.n_overlap }} tests have both measured, so take this as a rough hint.
     {% endif %}
   {% else %}
-    Pick an X and Y marker above to compare. Coupled patterns
-    (e.g. testosterone &amp; SHBG, HbA1c &amp; HDL) jump out here in a way
-    the per-marker view cannot show.
+    Pick two markers above to see how they relate. Some pairs move together
+    (like testosterone and SHBG); the per-marker view can't show that.
   {% endif %}
+</div>
+
+<div class="chart-host">
+  {{ q.chart_html | safe }}
 </div>

--- a/web/templates/partials/population.html
+++ b/web/templates/partials/population.html
@@ -5,17 +5,29 @@
   </div>
 {% else %}
 
-{% include "partials/_population_scatter.html" %}
-
 <div class="finding">
-  <strong>{{ p.n_clusters }} {{ p.type_word }}</strong> across your blood tests.
-  {% for s in p.sub_summaries %}{{ s | safe }}{% if not loop.last %} &nbsp;·&nbsp; {% endif %}{% endfor %}
+  {% if p.n_clusters > 1 %}
+    Each dot is one blood test, placed so tests with similar results across all
+    markers sit close together. They fall into <strong>{{ p.n_clusters }} groups</strong>.
+    {% if p.tentative %}
+      The grouping is on the weak side, so treat it as tentative.
+    {% endif %}
+  {% elif p.bic_pairs|length == 1 %}
+    Each dot is one blood test, placed so similar tests sit close together. There
+    are too few tests here to look for separate groups.
+  {% else %}
+    Each dot is one blood test, placed so similar tests sit close together. They
+    don't split into separate groups.
+  {% endif %}
   {% if p.small_sample %}
     <div class="t-quiet" style="margin-top: 0.5rem;">
-      Small sample ({{ p.n_patients }} tests) — clusters are a starting point; results stabilise around 200+ tests.
+      This is only {{ p.n_patients }} tests, so treat the groups as a rough picture.
+      They firm up with a few hundred.
     </div>
   {% endif %}
 </div>
+
+{% include "partials/_population_scatter.html" %}
 
 <section class="section">
   <div class="t-eyebrow">What defines each cluster</div>
@@ -59,25 +71,6 @@
   <div class="chart-host">
     {{ p.heatmap_html | safe }}
   </div>
-</details>
-
-<details class="disclosure">
-  <summary>Technical details</summary>
-  <p class="t-meta">
-    Analysis used {{ p.n_cluster_dims }} dimensions capturing {{ p.var_pct }}% of total variation.
-    {% if p.bic_pairs|length == 1 %}
-      Only a single cluster was evaluated — {{ p.n_patients }} patients is below the
-      evidence floor (50+ needed to test for clusters). Reported as one cluster by
-      default, not by BIC comparison.
-    {% else %}
-      Number of clusters selected by BIC (lower = better fit):
-      {% for n, bic in p.bic_pairs %}
-        <strong>{{ n }} clusters</strong>: {{ "%d"|format(bic) }}{% if not loop.last %} · {% endif %}
-      {% endfor %}{% if p.delta_bic is not none %},
-        beating a single cluster by ΔBIC {{ "%.0f"|format(p.delta_bic) }}{% if p.tentative %}
-        — strong but not overwhelming evidence; treat the clusters as tentative{% endif %}{% endif %}.
-    {% endif %}
-  </p>
 </details>
 
 {% endif %}


### PR DESCRIPTION
## What
A round of UI tidying across the Groups, Clusters and Correlations tabs.

**Banner moved + rewritten.** The summary banner now sits **above each graph** (right below the controls) instead of underneath, and the copy is rewritten in plain, teacher-style English — what the chart is showing, in normal words:
- Groups: *"Your Free Testosterone results split into 2 groups. Most (71%) sit around 0.44 nmol/L, and 29% around 0.20 nmol/L. Each curve on the chart is one group."*
- Clusters: *"Each dot is one blood test, placed so tests with similar results across all markers sit close together. They fall into 2 groups."*
- Correlations: *"Each dot is one blood test. As LDL Cholesterol goes up, SHBG tends to go up too (strong link, r = +0.78 across 80 tests)."*

**Removed clutter (per request):**
- The Clusters status text "N blood tests · M markers used".
- The Correlations status text "auto-picked: strongest of N candidate pairs · r=… · N tests".
- The **"Technical details"** disclosure on Groups and Clusters.

## Kept the honesty
The "Technical details" section held the #58 confidence signals (ΔBIC margin, "tentative" split, "too few tests / below the evidence floor"). Rather than lose those, the meaningful ones are **folded into the plain banner**: e.g. *"The split is on the weak side, so treat the groups as tentative"* and *"There are too few tests here to look for separate groups, so they're shown as one."*

## Cleanup
Dropping the redundant per-cluster one-liner (the "What defines each cluster" cards already cover it) and the Technical-details section left several dead context fields — removed: `sub_summaries`, `type_word`, `var_pct`, the population/explorer `delta_bic`, and the population `n_markers`.

## Verification
- Screenshots confirm the banner sits above each chart with no status clutter and no Technical-details section.
- Templates + context copy only — `analysis.py` untouched, `demo_cache.pkl` unchanged.
- Updated the one test that asserted the old below-floor wording; `ruff check .` clean; full suite **279 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)